### PR TITLE
Multigrid merge: part 3

### DIFF
--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -87,7 +87,6 @@ PYBIND11_MODULE (core, module)
     // Model
     py::class_<Model> (module, "Model")
         // attributes
-        .def_readwrite ("writing_populations_to_disk", &Model::writing_populations_to_disk)
         .def_readwrite ("parameters",     &Model::parameters)
         .def_readwrite ("geometry",       &Model::geometry)
         .def_readwrite ("chemistry",      &Model::chemistry)
@@ -134,6 +133,8 @@ PYBIND11_MODULE (core, module)
         // io
         .def_readwrite ("n_off_diag",         &Parameters::n_off_diag)
         .def_readwrite ("max_width_fraction", &Parameters::max_width_fraction)
+        .def_readwrite ("writing_populations_to_disk", &Parameters::writing_populations_to_disk)
+        .def_readwrite ("max_matrix_size", &Parameters::max_matrix_size)
         // setters
         .def ("set_model_name",               &Parameters::set_model_name          )
         .def ("set_dimension",                &Parameters::set_dimension           )

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -87,6 +87,7 @@ PYBIND11_MODULE (core, module)
     // Model
     py::class_<Model> (module, "Model")
         // attributes
+        .def_readwrite ("writing_populations_to_disk", &Model::writing_populations_to_disk)
         .def_readwrite ("parameters",     &Model::parameters)
         .def_readwrite ("geometry",       &Model::geometry)
         .def_readwrite ("chemistry",      &Model::chemistry)
@@ -111,6 +112,7 @@ PYBIND11_MODULE (core, module)
         .def ("compute_spectral_discretisation", (int (Model::*)(const Real width)) &Model::compute_spectral_discretisation)
         .def ("compute_spectral_discretisation", (int (Model::*)(const long double nu_min, const long double nu_max)) &Model::compute_spectral_discretisation)
         .def ("compute_LTE_level_populations",                                      &Model::compute_LTE_level_populations)
+        .def ("restart_from_iteration",                                             &Model::restart_from_iteration)
         // .def ("compute_radiation_field",                                            &Model::compute_radiation_field)
         .def ("compute_radiation_field_feautrier_order_2",                          &Model::compute_radiation_field_feautrier_order_2)
         .def ("compute_radiation_field_shortchar_order_0",                          &Model::compute_radiation_field_shortchar_order_0)
@@ -363,14 +365,17 @@ PYBIND11_MODULE (core, module)
         .def_readwrite ("population_prev1", &LineProducingSpecies::population_prev1)
         .def_readwrite ("population_prev2", &LineProducingSpecies::population_prev2)
         .def_readwrite ("population_prev3", &LineProducingSpecies::population_prev3)
-        .def_readwrite ("populations",      &LineProducingSpecies::populations)
-        .def_readwrite ("RT",               &LineProducingSpecies::RT)
-        .def_readwrite ("LambdaStar",       &LineProducingSpecies::LambdaStar)
-        .def_readwrite ("LambdaTest",       &LineProducingSpecies::LambdaTest)
+        // .def_readwrite ("populations",      &LineProducingSpecies::populations)
+        // .def_readwrite ("RT",               &LineProducingSpecies::RT)
+        // .def_readwrite ("LambdaStar",       &LineProducingSpecies::LambdaStar)
+        // .def_readwrite ("LambdaTest",       &LineProducingSpecies::LambdaTest)
         // functions
+        .def ("index",                      &LineProducingSpecies::index)
+        .def ("get_all_level_pops",         &LineProducingSpecies::get_all_level_pops)
+        .def ("set_all_level_pops",         &LineProducingSpecies::set_all_level_pops)
+        // io
         .def ("read",                       &LineProducingSpecies::read)
         .def ("write",                      &LineProducingSpecies::write)
-        .def ("index",                      &LineProducingSpecies::index)
         // constructor
         .def (py::init<>());
 

--- a/src/model/lines/lineProducingSpecies/lineProducingSpecies.cpp
+++ b/src/model/lines/lineProducingSpecies/lineProducingSpecies.cpp
@@ -16,12 +16,12 @@ void LineProducingSpecies :: read (const Io& io, const Size l)
     quadrature.read (io, l);
 
 
-    RT        .resize (parameters.npoints()*linedata.nlev,
-                       parameters.npoints()*linedata.nlev );
-    LambdaStar.resize (parameters.npoints()*linedata.nlev,
-                       parameters.npoints()*linedata.nlev );
-    LambdaTest.resize (parameters.npoints()*linedata.nlev,
-                       parameters.npoints()*linedata.nlev );
+    // RT        .resize (parameters.npoints()*linedata.nlev,
+    //                    parameters.npoints()*linedata.nlev );
+    // LambdaStar.resize (parameters.npoints()*linedata.nlev,
+    //                    parameters.npoints()*linedata.nlev );
+    // LambdaTest.resize (parameters.npoints()*linedata.nlev,
+    //                    parameters.npoints()*linedata.nlev );
 
     lambda.initialize (linedata.nrad);
 

--- a/src/model/lines/lineProducingSpecies/lineProducingSpecies.hpp
+++ b/src/model/lines/lineProducingSpecies/lineProducingSpecies.hpp
@@ -37,17 +37,18 @@ struct LineProducingSpecies
     VectorXr population;             ///< level population (most recent)
     Real1    population_tot;         ///< total level population (sum over levels)
 
-    vector<VectorXr> populations;    ///< list of populations in previous iterations
-    vector<VectorXr> residuals;      ///< list of residuals in the populations
+    // DO NOT REINTRODUCE THESE VARIABLES WITHOUT MAKING SURE WE DO NOT HAVE A MEMORY LEAK
+    // vector<VectorXr> populations;    ///< list of populations in previous iterations
+    // vector<VectorXr> residuals;      ///< list of residuals in the populations
 
 
     VectorXr population_prev1;       ///< level populations 1 iteration  back
     VectorXr population_prev2;       ///< level populations 2 iterations back
     VectorXr population_prev3;       ///< level populations 3 iterations back
 
-    SparseMatrix<Real> RT;
-    SparseMatrix<Real> LambdaTest;
-    SparseMatrix<Real> LambdaStar;
+    // SparseMatrix<Real> RT;
+    // SparseMatrix<Real> LambdaTest;
+    // SparseMatrix<Real> LambdaStar;
 
     void read  (const Io& io, const Size l);
     void write (const Io& io, const Size l) const;
@@ -60,8 +61,11 @@ struct LineProducingSpecies
     inline Real get_emissivity (const Size p, const Size k) const;
     inline Real get_opacity    (const Size p, const Size k) const;
 
+    inline Real get_level_pop  (const Size p, const Size i) const;
+    inline void set_level_pop  (const Size p, const Size i, const Real value);
+
     inline void check_for_convergence (
-        const Real pop_prec );
+        const Real pop_prec , vector<Size> &points_in_grid);
 
     inline void update_using_LTE (
         const Double2      &abundance,
@@ -69,10 +73,21 @@ struct LineProducingSpecies
 
     inline void update_using_statistical_equilibrium (
         const Double2      &abundance,
-        const Vector<Real> &temperature );
+        const Vector<Real> &temperature,
+        vector<Size> &points_in_grid);
+
+    //refactoring from update_using_statistical_equilibrium
+    inline VectorXr solve_statistical_equilibrium(
+      const Double2      &abundance,
+      const Vector<Real> &temperature,
+      vector<Size> &points_to_use);
 
     inline void update_using_Ng_acceleration ();
-    inline void update_using_acceleration (const Size order);
+    // inline void update_using_acceleration (const Size order);
+
+
+    inline void set_all_level_pops(VectorXr new_population);
+    inline VectorXr get_all_level_pops();
 };
 
 

--- a/src/model/lines/lineProducingSpecies/lineProducingSpecies.tpp
+++ b/src/model/lines/lineProducingSpecies/lineProducingSpecies.tpp
@@ -271,16 +271,13 @@ inline void LineProducingSpecies :: update_using_statistical_equilibrium (
     std::cout<<"setting vector population"<<std::endl;
     VectorXr new_population = VectorXr::Zero (parameters.npoints()*linedata.nlev);
 
-    const Size max_matrix_size=100*1024*1024;//hundred megabyte
-    // It turns out that due to using triplets to construct the sparse matrix, the total extra memory needed for this calculation is about three times this number
-
     // const unsigned long long int total_non_zeros = parameters.npoints() * (      linedata.nlev
     //                                                + 6 * linedata.nrad
     //                                                + 4 * linedata.ncol_tot );
 
     // We can split our block diagonal matrix if there are no non-local contributions
     if (parameters.n_off_diag==0){
-        Size n_points_per_block=max_matrix_size/((linedata.nlev + 6 * linedata.nrad + 4 * linedata.ncol_tot )*sizeof(Real));
+        Size n_points_per_block=parameters.max_matrix_size/((linedata.nlev + 6 * linedata.nrad + 4 * linedata.ncol_tot )*sizeof(Real));
         Size n_different_matrices=(points_in_grid.size()+(n_points_per_block-1))/n_points_per_block;//rounding up
         std::cout<<"Splitting big matrix into n parts: "<<n_different_matrices<<std::endl;
 
@@ -288,15 +285,20 @@ inline void LineProducingSpecies :: update_using_statistical_equilibrium (
         for (Size idx=0;idx<n_different_matrices;idx++)
         {
             Size firstidx=idx*n_points_per_block;
-            Size lastidx=std::min(static_cast<Size>(points_in_grid.size()-1),static_cast<Size>((idx+1)*n_points_per_block-1));
+            Size last_index_in_vector=points_in_grid.size()-1;
+            Size last_index_in_block=(idx+1)*n_points_per_block-1;
+            Size lastidx=std::min(last_index_in_vector,last_index_in_block);
+
             vector<Size> current_points_in_block = std::vector<Size>(points_in_grid.begin() + firstidx, points_in_grid.begin()+lastidx+1);
+
             VectorXr resulting_y = solve_statistical_equilibrium(abundance,temperature,current_points_in_block);//does not need to be continguous
 
-            //and finally putting those resulting y values at the right place in the y vector
+            //and finally putting those resulting y values at the right place in the new population vector
             Size temp_idx=0;
             for (Size point_in_block:current_points_in_block)
             {
-                new_population(Eigen::seq(index(point_in_block,0),index(point_in_block,linedata.nlev-1)))=resulting_y(Eigen::seq(index(temp_idx,0),index(temp_idx,linedata.nlev-1)));
+                new_population(Eigen::seq(index(point_in_block, 0),index(point_in_block, linedata.nlev-1)))
+                  =resulting_y(Eigen::seq(index(temp_idx      , 0),index(temp_idx      , linedata.nlev-1)));
                 temp_idx++;
             }
         }

--- a/src/model/lines/lines.cpp
+++ b/src/model/lines/lines.cpp
@@ -7,7 +7,6 @@ const string prefix = "lines/";
 
 ///  Reader for the Lines data
 ///    @param[in] io         : io object to read with
-///    @param[in] parameters : model parameters object
 //////////////////////////////////////////////////////
 void Lines :: read (const Io& io)
 {
@@ -99,12 +98,12 @@ void Lines :: iteration_using_LTE (const Double2 &abundance, const Vector<Real> 
 }
 
 
-void Lines :: iteration_using_Ng_acceleration (const Real pop_prec)
+void Lines :: iteration_using_Ng_acceleration (const Real pop_prec, vector<Size> &points_in_grid)
 {
     for (LineProducingSpecies &lspec : lineProducingSpecies)
     {
         lspec.update_using_Ng_acceleration ();
-        lspec.check_for_convergence        (pop_prec);
+        lspec.check_for_convergence        (pop_prec,points_in_grid);
     }
 
     set_emissivity_and_opacity ();
@@ -116,14 +115,15 @@ void Lines :: iteration_using_Ng_acceleration (const Real pop_prec)
 void Lines :: iteration_using_statistical_equilibrium (
     const Double2      &abundance,
     const Vector<Real> &temperature,
-    const Real          pop_prec )
+    const Real          pop_prec,
+    vector<Size> &points_in_grid)
 {
     for (LineProducingSpecies &lspec : lineProducingSpecies)
     {
-        lspec.update_using_statistical_equilibrium (abundance, temperature);
-        lspec.check_for_convergence                (pop_prec);
+        lspec.update_using_statistical_equilibrium (abundance, temperature, points_in_grid);
+        lspec.check_for_convergence                (pop_prec, points_in_grid);
     }
-
+    std::cout<<"setting emissivity and opacity"<<std::endl;
     set_emissivity_and_opacity ();
 
     //gather_emissivities_and_opacities ();

--- a/src/model/lines/lines.cpp
+++ b/src/model/lines/lines.cpp
@@ -123,7 +123,6 @@ void Lines :: iteration_using_statistical_equilibrium (
         lspec.update_using_statistical_equilibrium (abundance, temperature, points_in_grid);
         lspec.check_for_convergence                (pop_prec, points_in_grid);
     }
-    std::cout<<"setting emissivity and opacity"<<std::endl;
     set_emissivity_and_opacity ();
 
     //gather_emissivities_and_opacities ();

--- a/src/model/lines/lines.hpp
+++ b/src/model/lines/lines.hpp
@@ -38,10 +38,12 @@ struct Lines
     void iteration_using_statistical_equilibrium (
         const Double2      &abundance,
         const Vector<Real> &temperature,
-        const Real          pop_prec             );
+        const Real          pop_prec,
+        vector<Size> &points_in_grid            );
 
     void iteration_using_Ng_acceleration (
-        const Real pop_prec              );
+        const Real pop_prec,
+        vector<Size> &points_in_grid            );
 
     inline Size      index (const Size p, const Size line_index     ) const;
     inline Size line_index (              const Size l, const Size k) const;
@@ -51,6 +53,12 @@ struct Lines
     inline void set_inverse_width (const Thermodynamics& thermodynamics);
 
     void gather_emissivities_and_opacities ();
+
+    inline void set_all_level_pops(vector<VectorXr> new_population);
+    inline vector<VectorXr> get_all_level_pops();
+
+    inline void write_populations_of_iteration(const Io& io, const Size it, const Size lvl) const;
+    inline void read_populations_of_iteration(const Io& io, const Size it, const Size lvl);
 };
 
 

--- a/src/model/lines/lines.tpp
+++ b/src/model/lines/lines.tpp
@@ -74,3 +74,54 @@ inline void Lines :: set_inverse_width (const Thermodynamics& thermodynamics)
         }
     })
 }
+
+///  Sets the vector (per species) of vectors (per line) of all level populations
+///    @param[in]  new_population: the new level populations
+//////////////////////////////////////////////////////////////////////////////////
+inline void Lines :: set_all_level_pops(vector<VectorXr> new_population)
+{
+    threaded_for (i, parameters.nlspecs(),
+        lineProducingSpecies[i].set_all_level_pops(new_population[i]);
+    )
+}
+
+///  Returns the vector (per species) of vectors (per line) of all level populations
+////////////////////////////////////////////////////////////////////////////////////
+inline vector<VectorXr> Lines :: get_all_level_pops()
+{
+    vector<VectorXr> toreturn;
+    toreturn.reserve(parameters.nlspecs());
+    //No threaded for possible, because we might push back in a random order
+    for (Size i=0; i<parameters.nlspecs(); i++)
+    {
+        toreturn.push_back(lineProducingSpecies[i].get_all_level_pops());
+    }
+    return toreturn;
+}
+
+///  Writes the level populations of a certain iteration
+////////////////////////////////////////////////////////
+//currently also writes the J_lin and J_eff due to using the already implemented lineProducingSpecies::write_populations
+inline void Lines::write_populations_of_iteration(const Io& io, const Size it, const Size lvl) const
+{
+    const string tag_it="lvl"+std::to_string(lvl)+"it"+std::to_string(it);
+    for (Size l = 0; l < parameters.nlspecs(); l++)
+    {
+        lineProducingSpecies[l].write_populations (io, l, tag_it);
+    }
+}
+
+///  Reads the level populations of a given iteration
+///    @param[in]:  io: Reference to the Io structure
+///    @param[in]:  it: The number of the iteration to read from
+///    @param[in]:  lvl: The coarsening level to read from
+///////////////////////////////////////////////////////
+//currently also reads the J_lin and J_eff due to using the already implemented lineProducingSpecies::write_populations
+inline void Lines::read_populations_of_iteration(const Io& io, const Size it, const Size lvl)
+{
+    const string tag_it="lvl"+std::to_string(lvl)+"it"+std::to_string(it);
+    for (Size l = 0; l < parameters.nlspecs(); l++)
+    {
+        lineProducingSpecies[l].read_populations (io, l, tag_it);
+    }
+}

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -499,7 +499,7 @@ int Model :: compute_level_populations (
         }
 
         //If enabled, we now write the level populations to the hdf5 file
-        if (writing_populations_to_disk){
+        if (parameters.writing_populations_to_disk){
           IoPython io = IoPython ("hdf5", parameters.model_name());
           lines.write_populations_of_iteration(io, iteration, geometry.points.multiscale.get_curr_coars_lvl());
           std::cout<<"Wrote populations to disk"<<std::endl;

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -293,7 +293,7 @@ int Model :: compute_LTE_level_populations ()
 ///    @param[in] lvl : The coarsening level to start from
 //////////////////////////////////////////////////////////////////////////////////
 ///  Note: when the level populations cannot be read, starts from LTE instead without warning
-///  Note: currently no state of where we are in any multilevel operation is stored, so unless changed, please use this only with without multigrid or just naive multigrid (then the number of iterations done that is reported will be incorrect (because it doesnt count the iterations prior to loading))
+///  Note: currently no state of where we are in any multilevel operation is stored, so unless changed, please use this only without multigrid or just naive multigrid (then the number of iterations done that is reported will be incorrect (because it doesnt count the iterations prior to loading))
 int Model :: restart_from_iteration(Size iteration, Size lvl)
 {// TODO: currently, the mgController information is NOT SAVED, so this is not that useful for restarting a multigrid scheme
   compute_LTE_level_populations();

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -117,7 +117,7 @@ int Model :: compute_spectral_discretisation ()
         {
             nmbrs_inverted[nmbrs[fl]] = fl;
 
-            radiation.frequencies.appears_in_line_integral[fl] = false;;
+            radiation.frequencies.appears_in_line_integral[fl] = false;
             radiation.frequencies.corresponding_l_for_spec[fl] = parameters.nfreqs();
             radiation.frequencies.corresponding_k_for_tran[fl] = parameters.nfreqs();
             radiation.frequencies.corresponding_z_for_line[fl] = parameters.nfreqs();
@@ -164,8 +164,8 @@ int Model :: compute_spectral_discretisation (const Real width)
         Real1 freqs (parameters.nfreqs());
         Size1 nmbrs (parameters.nfreqs());
 
-        Size index0 = 0;
-        Size index1 = 0;
+        Size index0 = 0;//temp index for line number
+        Size index1 = 0;//temp index for frequencies
 
 
         // Add the line frequencies (over the profile)
@@ -215,7 +215,7 @@ int Model :: compute_spectral_discretisation (const Real width)
             radiation.frequencies.corresponding_z_for_line[fl] = parameters.nfreqs();
         }
 
-        Size index2 = 0;
+        Size index2 = 0;//temp index for lookup table from above
 
         for (Size l = 0; l < parameters.nlspecs(); l++)
         {
@@ -245,8 +245,8 @@ int Model :: compute_spectral_discretisation (const Real width)
 
 ///  Computer for spectral (=frequency) discretisation
 ///  Gives same frequency bins to each point
-///    @param[in] min : minimal frequency
-///    @param[in] max : maximal frequency
+///    @param[in] nu_min : minimal frequency
+///    @param[in] nu_max : maximal frequency
 ///////////////////////////////////////////////////////
 int Model :: compute_spectral_discretisation (
     const long double nu_min,
@@ -288,6 +288,24 @@ int Model :: compute_LTE_level_populations ()
     return (0);
 }
 
+///  Restarting from the iteration levelpops, assuming it has been written to disk
+///    @param[in] iteration : The iteration to start from
+///    @param[in] lvl : The coarsening level to start from
+//////////////////////////////////////////////////////////////////////////////////
+///  Note: when the level populations cannot be read, starts from LTE instead without warning
+///  Note: currently no state of where we are in any multilevel operation is stored, so unless changed, please use this only with without multigrid or just naive multigrid (then the number of iterations done that is reported will be incorrect (because it doesnt count the iterations prior to loading))
+int Model :: restart_from_iteration(Size iteration, Size lvl)
+{// TODO: currently, the mgController information is NOT SAVED, so this is not that useful for restarting a multigrid scheme
+  compute_LTE_level_populations();
+  IoPython io = IoPython ("hdf5", parameters.model_name());
+  lines.read_populations_of_iteration(io, iteration, lvl);
+  std::cout<<"Read populations from disk"<<std::endl;
+  lines.set_emissivity_and_opacity ();
+  std::cout<<"Restarting from iteration: "<<iteration<<std::endl;
+  iteration_to_start_from=iteration;
+  return (0);
+}
+
 
 ///  Computer for the radiation field
 /////////////////////////////////////
@@ -326,17 +344,48 @@ int Model :: compute_radiation_field_feautrier_order_2 ()
     return (0);
 }
 
+// //// also no declaration here in .hpp file; thus commented out
+// ///  Computer for the radiation field
+// /////////////////////////////////////
+// int Model :: compute_radiation_field_2nd_order_Feautrier ()
+// {
+//     cout << "Computing radiation field..." << endl;
+//
+//     const Size length_max = 4*parameters.npoints() + 1;
+//     const Size  width_max =   parameters.nfreqs ();
+//
+//
+//     cout << "npoints = " << parameters.npoints() << endl;
+//     cout << "nfreqs  = " << parameters.nfreqs () << endl;
+//
+//     cout << "l_max = " << length_max << endl;
+//     cout << "w_max = " <<  width_max << endl;
+//
+//     Solver solver (length_max, width_max, parameters.n_off_diag);
+//     solver.solve_2nd_order_Feautrier (*this);
+//
+//     return (0);
+// }
+
 
 ///  Compute the effective mean intensity in a line
 ///////////////////////////////////////////////////
 int Model :: compute_Jeff ()
 {
+
+    //as usual, only do this for the points currently in the grid
+    vector<Size> points_in_grid=geometry.points.multiscale.get_current_points_in_grid();
+    Size nbpoints=points_in_grid.size();
+
+
     for (LineProducingSpecies &lspec : lines.lineProducingSpecies)
     {
        // Lambda = MatrixXd::Zero (lspec.population.size(), lspec.population.size());
 
-        threaded_for (p, parameters.npoints(),
+        threaded_for (idx, nbpoints,
         {
+            const Size p=points_in_grid[idx];
+
             for (Size k = 0; k < lspec.linedata.nrad; k++)
             {
                 const Size1 freq_nrs = lspec.nr_line[p][k];
@@ -371,14 +420,17 @@ int Model :: compute_Jeff ()
 }
 
 
-///  compute level populations from statistical equilibrium
+///  Compute level populations from statistical equilibrium
 ///////////////////////////////////////////////////////////
 int Model :: compute_level_populations_from_stateq ()
 {
+    vector<Size> points_in_grid=geometry.points.multiscale.get_current_points_in_grid();
+
     lines.iteration_using_statistical_equilibrium (
             chemistry.species.abundance,
             thermodynamics.temperature.gas,
-            parameters.pop_prec()                 );
+            parameters.pop_prec(),
+            points_in_grid                       );
 
     return (0);
 }
@@ -386,10 +438,9 @@ int Model :: compute_level_populations_from_stateq ()
 
 ///  Compute level populations self-consistenly with the radiation field
 ///  assuming statistical equilibrium (detailed balance for the levels)
-///  @param[in] io                  : io object (for writing level populations)
 ///  @param[in] use_Ng_acceleration : true if Ng acceleration has to be used
 ///  @param[in] max_niterations     : maximum number of iterations
-///  @return number of iteration done
+///  @return Number of iterations done
 ///////////////////////////////////////////////////////////////////////////////
 int Model :: compute_level_populations (
     const bool use_Ng_acceleration,
@@ -402,7 +453,7 @@ int Model :: compute_level_populations (
     }
 
     // Initialize the number of iterations
-    int iteration        = 0;
+    int iteration        = iteration_to_start_from;
     int iteration_normal = 0;
 
     // Initialize errors
@@ -417,7 +468,6 @@ int Model :: compute_level_populations (
     {
         iteration++;
 
-        // logger.write ("Starting iteration ", iteration);
         cout << "Starting iteration " << iteration << endl;
 
         // Start assuming convergence
@@ -425,24 +475,34 @@ int Model :: compute_level_populations (
 
         if (use_Ng_acceleration && (iteration_normal == 4))
         {
-            lines.iteration_using_Ng_acceleration (parameters.pop_prec());
+            vector<Size> points_in_grid=geometry.points.multiscale.get_current_points_in_grid();
+            lines.iteration_using_Ng_acceleration (parameters.pop_prec(), points_in_grid);
 
             iteration_normal = 0;
         }
         else
         {
-            // logger.write ("Computing the radiation field...");
             cout << "Computing the radiation field..." << endl;
 
             compute_radiation_field_feautrier_order_2 ();
             compute_Jeff                              ();
 
+            vector<Size> points_in_grid=geometry.points.multiscale.get_current_points_in_grid();
+
             lines.iteration_using_statistical_equilibrium (
                 chemistry.species.abundance,
                 thermodynamics.temperature.gas,
-                parameters.pop_prec()                     );
+                parameters.pop_prec(),
+                points_in_grid);
 
             iteration_normal++;
+        }
+
+        //If enabled, we now write the level populations to the hdf5 file
+        if (writing_populations_to_disk){
+          IoPython io = IoPython ("hdf5", parameters.model_name());
+          lines.write_populations_of_iteration(io, iteration, geometry.points.multiscale.get_curr_coars_lvl());
+          std::cout<<"Wrote populations to disk"<<std::endl;
         }
 
 
@@ -458,7 +518,6 @@ int Model :: compute_level_populations (
 
             const double fnc = lines.lineProducingSpecies[l].fraction_not_converged;
 
-            // logger.write ("Already ", 100 * (1.0 - fnc), " % converged!");
             cout << "Already " << 100 * (1.0 - fnc) << " % converged!" << endl;
         }
     } // end of while loop of iterations
@@ -488,7 +547,8 @@ int Model :: compute_image (const Size ray_nr)
     return (0);
 }
 
-
+/// Sets the emmisivity and opacity
+///////////////////////////////////
 int Model :: set_eta_and_chi ()
 {
     Solver solver;
@@ -497,7 +557,8 @@ int Model :: set_eta_and_chi ()
     return (0);
 }
 
-
+/// Sets the boundary conditions
+////////////////////////////////
 int Model :: set_boundary_condition ()
 {
     Solver solver;

--- a/src/model/model.hpp
+++ b/src/model/model.hpp
@@ -10,13 +10,13 @@
 #include "thermodynamics/thermodynamics.hpp"
 #include "lines/lines.hpp"
 #include "radiation/radiation.hpp"
+#include <set>
 #include "image/image.hpp"
 
 /// The main structure, which has a reference to most of the other structures
 /////////////////////////////////////////////////////////////////////////////
 struct Model
 {
-    bool writing_populations_to_disk=false;   ///< Toggle for writing the level populations after each iteration
 
     Size iteration_to_start_from=0;           ///< Number to start the iterations from (can be non-zero when loading the level populations)
 

--- a/src/model/model.hpp
+++ b/src/model/model.hpp
@@ -12,9 +12,14 @@
 #include "radiation/radiation.hpp"
 #include "image/image.hpp"
 
-
+/// The main structure, which has a reference to most of the other structures
+/////////////////////////////////////////////////////////////////////////////
 struct Model
 {
+    bool writing_populations_to_disk=false;   ///< Toggle for writing the level populations after each iteration
+
+    Size iteration_to_start_from=0;           ///< Number to start the iterations from (can be non-zero when loading the level populations)
+
     Parameters     parameters;
     Geometry       geometry;
     Chemistry      chemistry;
@@ -53,10 +58,11 @@ struct Model
     int compute_Jeff                              ();
     int compute_level_populations_from_stateq     ();
     int compute_level_populations                 (
-        // const Io   &io,
         const bool  use_Ng_acceleration,
         const long  max_niterations     );
     int compute_image                             (const Size ray_nr);
+
+    int restart_from_iteration(Size iteration, Size lvl);
 
     Double1 error_max;
     Double1 error_mean;

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -130,6 +130,10 @@ struct Parameters
 
     long n_off_diag = 0;
 
+    Size max_matrix_size=100*1024*1024;// max temp matrix size when solving for the level populations (do this times 3 for the actual max size) //hundred megabyte
+
+    bool writing_populations_to_disk=false;   ///< Toggle for writing the level populations after each iteration
+
     double max_width_fraction = 0.5;
 
     void read (const Io &io);


### PR DESCRIPTION
Bounded the memory cost for solving for the level populations.
This change also allows us to easily generalize this solving procedure to coarser grids.
Also added support for saving/loading the level populations to/from disk.

This should be the last merge without any mention of multigrid.