### PR TITLE
Fixed typo in computing ray length.

### DIFF
--- a/src/model/geometry/geometry.tpp
+++ b/src/model/geometry/geometry.tpp
@@ -179,7 +179,7 @@ accel inline Size Geometry :: get_ray_length (
     if (valid_point(nxt))
     {
         Size         crt = o;
-        double shift_crt = get_shift <frame> (o, r, crt, Z);
+        double shift_crt = get_shift <frame> (o, r, crt, 0.0);
         double shift_nxt = get_shift <frame> (o, r, nxt, Z);
 
         l += get_n_interpl (shift_crt, shift_nxt, dshift_max);


### PR DESCRIPTION
As segfaults can occur when the ray length is computed incorrectly, this should be fixed. This resulted in a mismatch between what `get_max_ray_lengths` and `trace_ray` reports as last point index. Note that this part of the code might become obsolete once #93 is merged.