### PR TITLE
Adjusted benchmark suite by adding analytical benchmarks.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,4 +14,7 @@ cd $DIR
 python -m pip uninstall magritte
 
 # echo "Installing magritte python package..."
-python setup.py install
+# python setup.py install
+bash compile.sh
+#setup.py install is deprecated
+python -m pip install .

--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 # The order of the channels above is critical!!!
 dependencies:
-  - python
+  - python=3.9
   - cmake
   - k3d
   - numpy

--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 # The order of the channels above is critical!!!
 dependencies:
-  - python=3.7
+  - python
   - cmake
   - k3d
   - numpy

--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics"
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )

--- a/tests/benchmarks/analytic/constant_velocity_gradient_1D.py
+++ b/tests/benchmarks/analytic/constant_velocity_gradient_1D.py
@@ -73,7 +73,7 @@ def create_model ():
     return #magritte.Model (modelFile)
 
 
-def run_model (nosave=False, benchindex=1):
+def run_model (nosave=False, benchindex=0, use_widgets=True):
 
     modelName = f'constant_velocity_gradient_1D'
     modelFile = f'{moddir}{modelName}.hdf5'
@@ -189,7 +189,10 @@ def run_model (nosave=False, benchindex=1):
         plt.figure(dpi=150)
         plt.plot(fs, us  [r,p,:], marker='.')
         plt.plot(fs, u_2f[r,p,:])
-    widgets.interact(plot, r=(0,hnrays-1,1), p=(0,npoints-1,1))
+
+    #during automated testing, the widgets only consume time to create
+    if use_widgets:
+        widgets.interact(plot, r=(0,hnrays-1,1), p=(0,npoints-1,1))
 
     error_u_0s = np.abs(tools.relative_error(us, u_0s))
     error_u_2f = np.abs(tools.relative_error(us, u_2f))

--- a/tests/benchmarks/analytic/constant_velocity_gradient_1D_image.py
+++ b/tests/benchmarks/analytic/constant_velocity_gradient_1D_image.py
@@ -73,7 +73,7 @@ def create_model ():
     return #magritte.Model (modelFile)
 
 
-def run_model (nosave=False, benchindex=0):
+def run_model (nosave=False, benchindex=0, use_widgets=True):
 
     modelName = f'constant_velocity_gradient_1D_image'
     modelFile = f'{moddir}{modelName}.hdf5'
@@ -164,7 +164,10 @@ def run_model (nosave=False, benchindex=0):
         plt.figure(dpi=150)
         plt.plot(fs, im  [p,:], marker='.')
         plt.plot(fs, im_a[p,:])
-    widgets.interact(plot, p=(0,npoints-1,1))
+
+    #during automated testing, the widgets only consume time to create
+    if use_widgets:
+        widgets.interact(plot, p=(0,npoints-1,1))
 
     error = np.abs(tools.relative_error(im, im_a))[:-1]
 
@@ -209,11 +212,11 @@ def run_model (nosave=False, benchindex=0):
     FEAUTRIER_AS_EXPECTED=True
     #if we are actually doing benchmarks, the accuracy will depend on how accurately we compute the optical depth
     if (benchindex==1):
-        FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<1.8e-5)
+        FEAUTRIER_AS_EXPECTED=(np.max(error)<1.8e-5)
     elif(benchindex==2):
-        FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<8e-6)
+        FEAUTRIER_AS_EXPECTED=(np.max(error)<8e-6)
     elif(benchindex==3):
-        FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<2e-8)
+        FEAUTRIER_AS_EXPECTED=(np.max(error)<2e-8)
 
     if not FEAUTRIER_AS_EXPECTED:
         print("Feautrier solver mean error too large: ", np.mean(error_u_2f), "bench nr: ", benchindex)

--- a/tests/benchmarks/analytic/density_distribution_1D_image.py
+++ b/tests/benchmarks/analytic/density_distribution_1D_image.py
@@ -209,6 +209,15 @@ def run_model (a_or_b, nosave=False):
         plt.xscale('log')
         plt.savefig(f'{resdir}{modelName}_cumu-{timestamp}.png', dpi=150)
 
+    #setting 'b' not yet used for testing
+    if a_or_b == 'a':
+        #error bounds are chosen somewhat arbitrarily, based on previously obtained results; this should prevent serious regressions.
+        FEAUTRIER_AS_EXPECTED=(np.mean(error)<2e-3)
+        if not FEAUTRIER_AS_EXPECTED:
+            print("Feautrier solver mean error too large: ", np.mean(error))
+
+        return (FEAUTRIER_AS_EXPECTED)
+
     return
 
 

--- a/tests/benchmarks/analytic/density_distribution_1D_image.py
+++ b/tests/benchmarks/analytic/density_distribution_1D_image.py
@@ -83,7 +83,7 @@ def create_model (a_or_b):
     return #magritte.Model (modelFile)
 
 
-def run_model (a_or_b, nosave=False):
+def run_model (a_or_b, nosave=False, use_widgets=True):
 
     modelName = f'density_distribution_VZ{a_or_b}_1D_image'
     modelFile = f'{moddir}{modelName}.hdf5'
@@ -167,7 +167,10 @@ def run_model (a_or_b, nosave=False):
         plt.plot(fs,           tools.I_CMB(nu),                 label='CMB')
         plt.yscale('log')
         plt.legend()
-    widgets.interact(plot, p=(0,npoints-1,1))
+        
+    #during automated testing, the widgets only consume time to create
+    if use_widgets:
+        widgets.interact(plot, p=(0,npoints-1,1))
 
     error = np.abs(tools.relative_error(im, im_a))[:-1]
 

--- a/tests/benchmarks/analytic/test_benchmarks.py
+++ b/tests/benchmarks/analytic/test_benchmarks.py
@@ -2,8 +2,12 @@ from all_constant_single_ray import create_model as all_constant_setup
 from all_constant_single_ray import run_model as all_constant_run
 from density_distribution_1D import create_model as density_dist_setup
 from density_distribution_1D import run_model as density_dist_run
+from density_distribution_1D_image import create_model as density_dist_image_setup
+from density_distribution_1D_image import run_model as density_dist_image_run
 from constant_velocity_gradient_1D import create_model as velocity_gradient_setup
 from constant_velocity_gradient_1D import run_model as velocity_gradient_run
+from constant_velocity_gradient_1D_image import create_model as velocity_gradient_image_setup
+from constant_velocity_gradient_1D_image import run_model as velocity_gradient_image_run
 
 import pytest
 
@@ -32,9 +36,39 @@ class TestAnalytic:
             assert density_dist_run('a', nosave=True)
 
     @pytest.mark.incremental
+    class TestDensityDistribution1DImage:
+        def test_density_distribution1D_image_setup(self):
+            density_dist_image_setup('a')
+
+        def test_density_distribution1D_image_run(self):
+            assert density_dist_image_run('a', nosave=True)
+
+    @pytest.mark.incremental
     class TestVelocityGradient1D:
         def test_velocity_gradient_1D_setup(self):
             velocity_gradient_setup()
 
-        def test_velocity_gradient_1D_run(self):
-            assert velocity_gradient_run(nosave=True)
+        class TestVelocityGradient1DBenchmarks:
+            def test_velocity_gradient_1D_run_bench1(self):
+                assert velocity_gradient_run(nosave=True, benchindex=1)
+            def test_velocity_gradient_1D_run_bench2(self):
+                assert velocity_gradient_run(nosave=True, benchindex=2)
+            def test_velocity_gradient_1D_run_bench3(self):
+                assert velocity_gradient_run(nosave=True, benchindex=3)
+
+    @pytest.mark.incremental
+    class TestVelocityGradient1DImage:
+        def test_velocity_gradient_1D_image_setup(self):
+            velocity_gradient_image_setup()
+
+        class TestVelocityGradient1DImageBenchmarks:
+            def test_velocity_gradient_1D_image_run_bench1(self):
+                assert velocity_gradient_run(nosave=True, benchindex=1)
+            def test_velocity_gradient_1D_image_run_bench2(self):
+                assert velocity_gradient_run(nosave=True, benchindex=2)
+            def test_velocity_gradient_1D_image_run_bench3(self):
+                assert velocity_gradient_run(nosave=True, benchindex=3)
+
+
+
+#TODO ADD ALL ANALYTIC BENCHMARKS, get some manner of performance somewhere else

--- a/tests/benchmarks/analytic/test_benchmarks.py
+++ b/tests/benchmarks/analytic/test_benchmarks.py
@@ -41,7 +41,7 @@ class TestAnalytic:
             density_dist_image_setup('a')
 
         def test_density_distribution1D_image_run(self):
-            assert density_dist_image_run('a', nosave=True)
+            assert density_dist_image_run('a', nosave=True, use_widgets=False)
 
     @pytest.mark.incremental
     class TestVelocityGradient1D:
@@ -50,11 +50,11 @@ class TestAnalytic:
 
         class TestVelocityGradient1DBenchmarks:
             def test_velocity_gradient_1D_run_bench1(self):
-                assert velocity_gradient_run(nosave=True, benchindex=1)
+                assert velocity_gradient_run(nosave=True, benchindex=1, use_widgets=False)
             def test_velocity_gradient_1D_run_bench2(self):
-                assert velocity_gradient_run(nosave=True, benchindex=2)
+                assert velocity_gradient_run(nosave=True, benchindex=2, use_widgets=False)
             def test_velocity_gradient_1D_run_bench3(self):
-                assert velocity_gradient_run(nosave=True, benchindex=3)
+                assert velocity_gradient_run(nosave=True, benchindex=3, use_widgets=False)
 
     @pytest.mark.incremental
     class TestVelocityGradient1DImage:
@@ -63,11 +63,11 @@ class TestAnalytic:
 
         class TestVelocityGradient1DImageBenchmarks:
             def test_velocity_gradient_1D_image_run_bench1(self):
-                assert velocity_gradient_run(nosave=True, benchindex=1)
+                assert velocity_gradient_image_run(nosave=True, benchindex=1, use_widgets=False)
             def test_velocity_gradient_1D_image_run_bench2(self):
-                assert velocity_gradient_run(nosave=True, benchindex=2)
+                assert velocity_gradient_image_run(nosave=True, benchindex=2, use_widgets=False)
             def test_velocity_gradient_1D_image_run_bench3(self):
-                assert velocity_gradient_run(nosave=True, benchindex=3)
+                assert velocity_gradient_image_run(nosave=True, benchindex=3, use_widgets=False)
 
 
 

--- a/tests/benchmarks/numeric/run_phantom_3D_model_reduced.py
+++ b/tests/benchmarks/numeric/run_phantom_3D_model_reduced.py
@@ -46,7 +46,7 @@ def run_model (nosave=True):
 
     timer3 = tools.Timer('running model')
     timer3.start()
-    model.compute_level_populations (True, 10)
+    model.compute_level_populations_sparse (True, 10)
     # sum_J_2f=np.array(model.lines.lineProducingSpecies[0].Jlin)
 
     # model = magritte.Model (modelFile)


### PR DESCRIPTION
As we previously forgot to add benchmarks for imaging to the test suite, this is now included.
The downside is that the benchmark suite now takes a few minutes longer to run.
This could be improved by disabling the widgets during benchmarking, as they will not be viewed anyway.