### PR TITLE
Implemented ALI for short-characteristics method.

### DIFF
--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -265,6 +265,11 @@ PYBIND11_MODULE (core, module)
             "Compute the level populations for the model assuming statistical equilibrium until convergence, optionally using Ng-acceleration, and for the given maximum number of iterations. (Memory sparse option.)"
         )
         .def (
+            "compute_level_populations_shortchar",
+            &Model::compute_level_populations_shortchar,
+            "Compute the level populations using the short-characteristics solver for the model assuming statistical equilibrium until convergence, optionally using Ng-acceleration, and for the given maximum number of iterations."
+        )
+        .def (
             "compute_image",
             &Model::compute_image,
             "Compute an image for the model along the given ray."

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -689,6 +689,107 @@ int Model :: compute_level_populations_sparse (
 }
 
 
+
+///  Compute level populations self-consistenly with the radiation field
+///  assuming statistical equilibrium (detailed balance for the levels)
+///  @param[in] io                  : io object (for writing level populations)
+///  @param[in] use_Ng_acceleration : true if Ng acceleration has to be used
+///  @param[in] max_niterations     : maximum number of iterations
+///  @return number of iteration done
+///////////////////////////////////////////////////////////////////////////////
+int Model :: compute_level_populations_shortchar (
+    const bool use_Ng_acceleration,
+    const long max_niterations     )
+{
+    // Check spectral discretisation setting
+    if (spectralDiscretisation != SD_Lines)
+    {
+        throw std::runtime_error ("Spectral discretisation was not set for Lines!");
+    }
+
+    // Initialize the number of iterations
+    int iteration        = 0;
+    int iteration_normal = 0;
+
+    // Initialize errors
+    error_mean.clear ();
+    error_max .clear ();
+
+    // Initialize some_not_converged
+    bool some_not_converged = true;
+
+    // Iterate as long as some levels are not converged
+    while (some_not_converged && (iteration < max_niterations))
+    {
+        iteration++;
+
+        // logger.write ("Starting iteration ", iteration);
+        cout << "Starting iteration " << iteration << endl;
+
+        // Start assuming convergence
+        some_not_converged = false;
+
+        if (use_Ng_acceleration && (iteration_normal == 4))
+        {
+            lines.iteration_using_Ng_acceleration (parameters->pop_prec);
+
+            iteration_normal = 0;
+        }
+        else
+        {
+            // logger.write ("Computing the radiation field...");
+            cout << "Computing the radiation field..." << endl;
+
+            Timer timer_1("Compute Radiation Field");
+            timer_1.start();
+
+            compute_radiation_field_shortchar_order_0 ();
+            compute_Jeff                              ();
+
+            timer_1.stop();
+            timer_1.print_total();
+
+
+            Timer timer_2("Compute Statistical Equilibrium");
+            timer_2.start();
+
+            lines.iteration_using_statistical_equilibrium (
+                chemistry.species.abundance,
+                thermodynamics.temperature.gas,
+                parameters->pop_prec                            );
+
+            timer_2.stop();
+            timer_2.print_total();
+
+
+            iteration_normal++;
+        }
+
+
+        for (int l = 0; l < parameters->nlspecs(); l++)
+        {
+            error_mean.push_back (lines.lineProducingSpecies[l].relative_change_mean);
+            error_max .push_back (lines.lineProducingSpecies[l].relative_change_max);
+
+            if (lines.lineProducingSpecies[l].fraction_not_converged > 1.0 - parameters->convergence_fraction)
+            {
+                some_not_converged = true;
+            }
+
+            const double fnc = lines.lineProducingSpecies[l].fraction_not_converged;
+
+            // logger.write ("Already ", 100 * (1.0 - fnc), " % converged!");
+            cout << "Already " << 100.0 * (1.0 - fnc) << " % converged!" << endl;
+        }
+    } // end of while loop of iterations
+
+    // Print convergence stats
+    cout << "Converged after " << iteration << " iterations" << endl;
+
+    return iteration;
+}
+
+
 ///  Computer for the radiation field
 /////////////////////////////////////
 int Model :: compute_image (const Size ray_nr)

--- a/src/model/model.hpp
+++ b/src/model/model.hpp
@@ -79,6 +79,9 @@ struct Model
     int compute_level_populations_sparse          (
         const bool  use_Ng_acceleration,
         const long  max_niterations     );
+    int compute_level_populations_shortchar       (
+        const bool  use_Ng_acceleration,
+        const long  max_niterations     );
     int compute_image                             (const Size ray_nr);
     int compute_image_optical_depth               (const Size ray_nr);
 

--- a/src/solver/solver.tpp
+++ b/src/solver/solver.tpp
@@ -860,9 +860,14 @@ accel inline void Solver :: solve_shortchar_order_0 (
             const Real invr_mass = lspec.linedata.inverse_mass;
             const Real constante = lspec.linedata.A[k] * lspec.quadrature.weights[z] * w_ang;
 
-            Real inverse_chi=1.0/chi_c[f];
+            Real eta, chi;//eta is dummy var
+            //chi is not necessarily computed, so compute it to be sure
+            get_eta_and_chi <None>(model, o, k, freq_line, eta, chi);
+            Real inverse_chi=1.0/chi;
             Real phi = model.thermodynamics.profile(invr_mass, o, freq_line, freq);
-            Real L   = constante * freq * phi * (factor + 1.0) * inverse_chi;
+            // const Real lambda_factor = (dtau+expm1f(-dtau))/dtau;// If one wants to compute lambda a bit more accurately in case of dtau≃0.
+            // Real L   = constante * freq * phi * lambda_factor * inverse_chi;
+            Real L   = constante * freq * phi * (factor + 1.0) * inverse_chi;//using factor+1.0, the computed lambda elements can be negative if dtau very small; but then the lambda elements are also negligible
             lspec.lambda.add_element(o, k, o, L);
 
             //TODO: possible nonlocal lambda part // FIXME: probably incorrect chi used
@@ -1216,7 +1221,7 @@ inline void Solver :: compute_S_dtau_line_integrated <None> (Model& model, Size 
     //note: due to interaction with dtau when computing all sources individually, we do need to recompute Scurr and Snext for all position increments
 }
 
-/// Computes the opacity and optical depth in a hybrid manner
+/// Computes the source function and optical depth in a hybrid manner
 ///    @param[in/out] compute_curr_opacity: for deciding whether we need to compute the current opacity when using the trapezoidal rule
 ///    @param[in] currpoint : index of current point
 ///    @param[in] nextpoint : index of next point
@@ -1229,6 +1234,7 @@ inline void Solver :: compute_S_dtau_line_integrated <None> (Model& model, Size 
 ///    @param[out] dtau : optical depth increment to compute
 ///    @param[out] Scurr : source function at current point to compute
 ///    @param[out] Snext : source function at next point to compute
+/// Warning: depending on how large the doppler shift is, the opacity is NOT computed.
 template<ApproximationType approx>
 accel inline void Solver :: compute_source_dtau (Model& model, Size currpoint, Size nextpoint, Size line, Real curr_freq, Real next_freq, double curr_shift, double next_shift, Real dZ, bool& compute_curr_opacity, Real& dtaunext, Real& chicurr, Real& chinext, Real& Scurr, Real& Snext)
 {
@@ -1243,6 +1249,7 @@ accel inline void Solver :: compute_source_dtau (Model& model, Size currpoint, S
     {
         compute_curr_opacity=true;
         compute_S_dtau_line_integrated <approx> (model, currpoint, nextpoint, line, curr_freq, next_freq, dZ, dtaunext, Scurr, Snext);
+        //OPACITY IS NOT COMPUTED IN THIS BRANCH!
     }
     else
     {

--- a/src/solver/solver.tpp
+++ b/src/solver/solver.tpp
@@ -848,21 +848,25 @@ accel inline void Solver :: solve_shortchar_order_0 (
                                      + source_c[f] - source_n[f];
             tau[f] = dtau;
 
-            //Compute local lambda operator // TODO: check this implementatino when actually using this as a solver for NLTE intensities
-            // const Size k = model.radiation.frequencies.corresponding_k_for_tran[f];   // index of transition
-            // const Size z = model.radiation.frequencies.corresponding_z_for_line[f];   // index of quadrature point
-            // const Real w_ang = model.geometry.rays.weight[r];
-            //
-            // LineProducingSpecies &lspec = model.lines.lineProducingSpecies[l];
-            //
-            // const Real freq_line = lspec.linedata.frequency[k];
-            // const Real invr_mass = lspec.linedata.inverse_mass;
-            // const Real constante = lspec.linedata.A[k] * lspec.quadrature.weights[z] * w_ang;
-            //
-            // Real inverse_chi=1.0/chi_c[f];
-            // Real phi = model.thermodynamics.profile(invr_mass, o, freq_line, freq);
-            // Real L   = constante * freq * phi * (factor + 1.0) * inverse_chi;
-            // lspec.lambda.add_element(o, k, o, L);
+            //Compute local lambda operator // TODO: check this implementation when actually using this as a solver for NLTE intensities
+            const Size k = model.radiation.frequencies.corresponding_k_for_tran[f];   // index of transition
+            const Size z = model.radiation.frequencies.corresponding_z_for_line[f];   // index of quadrature point
+            const Real w_ang = model.geometry.rays.weight[r];
+
+            LineProducingSpecies &lspec = model.lines.lineProducingSpecies[l];
+
+            const Real freq_line = lspec.linedata.frequency[k];
+            const Real invr_mass = lspec.linedata.inverse_mass;
+            const Real constante = lspec.linedata.A[k] * lspec.quadrature.weights[z] * w_ang;
+
+            Real inverse_chi=1.0/chi_c[f];
+            Real phi = model.thermodynamics.profile(invr_mass, o, freq_line, freq);
+            Real L   = constante * freq * phi * (factor + 1.0) * inverse_chi;
+            lspec.lambda.add_element(o, k, o, L);
+
+            //TODO: possible nonlocal lambda part // FIXME: probably incorrect chi used
+            // L   = constante * freq * phi * (-factor * (1.0+dtau) - 1.0) * inverse_chi;
+            // lspec.lambda.add_element(o, k, nxt, L);
         }
 
         //For all frequencies, we need to use the same method for computing the optical depth

--- a/src/solver/solver.tpp
+++ b/src/solver/solver.tpp
@@ -831,7 +831,7 @@ accel inline void Solver :: solve_shortchar_order_0 (
         for (Size f = 0; f < model.parameters->nfreqs(); f++)
         {
             const Real freq = model.radiation.frequencies.nu(o, f);
-            const Size l    = model.radiation.frequencies.corresponding_line[f];
+            const Size l    = model.radiation.frequencies.corresponding_line[f];//line index
 
             compute_curr_opacity = true; // for the first point, we need to compute both the curr and next opacity (and source)
 
@@ -848,12 +848,13 @@ accel inline void Solver :: solve_shortchar_order_0 (
                                      + source_c[f] - source_n[f];
             tau[f] = dtau;
 
-            //Compute local lambda operator // TODO: check this implementation when actually using this as a solver for NLTE intensities
+            //Compute local lambda operator
+            const Size l_spec = model.radiation.frequencies.corresponding_l_for_spec[f];   // index of species
             const Size k = model.radiation.frequencies.corresponding_k_for_tran[f];   // index of transition
             const Size z = model.radiation.frequencies.corresponding_z_for_line[f];   // index of quadrature point
             const Real w_ang = model.geometry.rays.weight[r];
 
-            LineProducingSpecies &lspec = model.lines.lineProducingSpecies[l];
+            LineProducingSpecies &lspec = model.lines.lineProducingSpecies[l_spec];
 
             const Real freq_line = lspec.linedata.frequency[k];
             const Real invr_mass = lspec.linedata.inverse_mass;


### PR DESCRIPTION
Implemented local approximate lambda iteration for the (first order) short-characteristics method. Due to the first order nature of the solver, the result obtained in the vanZadelhoff1b benchmark is slightly different.