### PR TITLE
Change type of Real to double

### DIFF
--- a/src/io/cpp/io_cpp_text.cpp
+++ b/src/io/cpp/io_cpp_text.cpp
@@ -374,46 +374,46 @@ int IoText :: write_list (const string file_name, const Long1 &list) const
 }
 
 
-///  Reader for a list of doubles from a text file
-///    @param[in] file_name : path to file containing the list
-///    @param[in] list      : list to be read
-//////////////////////////////////////////////////////////////
-int IoText :: read_list (const string file_name, Double1 &list) const
-{
-  std::ifstream file (io_file + file_name + ".txt");
+// ///  Reader for a list of doubles from a text file
+// ///    @param[in] file_name : path to file containing the list
+// ///    @param[in] list      : list to be read
+// //////////////////////////////////////////////////////////////
+// int IoText :: read_list (const string file_name, Double1 &list) const
+// {
+//   std::ifstream file (io_file + file_name + ".txt");
+//
+//   long   n = 0;
+//
+//   while (file >> list[n])
+//   {
+//     n++;
+//   }
+//
+//   file.close();
+//
+//   return (0);
+// }
 
-  long   n = 0;
 
-  while (file >> list[n])
-  {
-    n++;
-  }
-
-  file.close();
-
-  return (0);
-}
-
-
-///  Writer for a list of strings to a text file
-///    @param[in] file_name : path to file to be written
-///    @param[in] list      : list to be written
-////////////////////////////////////////////////////////
-int IoText :: write_list (const string file_name, const Double1 &list) const
-{
-  std::ofstream file (io_file + file_name + ".txt");
-
-  file << std::scientific << std::setprecision (16);
-
-  for (long n = 0; n < list.size(); n++)
-  {
-    file << list[n] << endl;
-  }
-
-  file.close();
-
-  return (0);
-}
+// ///  Writer for a list of strings to a text file
+// ///    @param[in] file_name : path to file to be written
+// ///    @param[in] list      : list to be written
+// ////////////////////////////////////////////////////////
+// int IoText :: write_list (const string file_name, const Double1 &list) const
+// {
+//   std::ofstream file (io_file + file_name + ".txt");
+//
+//   file << std::scientific << std::setprecision (16);
+//
+//   for (long n = 0; n < list.size(); n++)
+//   {
+//     file << list[n] << endl;
+//   }
+//
+//   file.close();
+//
+//   return (0);
+// }
 
 
 ///  Reader for a list of doubles from a text file
@@ -638,58 +638,58 @@ int IoText :: write_array (const string file_name, const Long2 &array) const
 }
 
 
-///  Reader for an array of doubles from a text file
-///    @param[in] file_name : path to file containing the array
-///    @param[in] array     : array to be read
-///////////////////////////////////////////////////////////////
-int IoText :: read_array (const string file_name, Double2 &array) const
-{
-  std::ifstream file (io_file + file_name + ".txt");
+// ///  Reader for an array of doubles from a text file
+// ///    @param[in] file_name : path to file containing the array
+// ///    @param[in] array     : array to be read
+// ///////////////////////////////////////////////////////////////
+// int IoText :: read_array (const string file_name, Double2 &array) const
+// {
+//   std::ifstream file (io_file + file_name + ".txt");
+//
+//   string line;
+//
+//   for (long n1 = 0; n1 < array.size(); n1++)
+//   {
+//     std::getline (file, line);
+//
+//     std::stringstream ss (line);
+//
+//     for (long n2 = 0; n2 < array[n1].size(); n2++)
+//     {
+//       ss >> array[n1][n2];
+//     }
+//   }
+//
+//   file.close();
+//
+//   return (0);
+// }
 
-  string line;
 
-  for (long n1 = 0; n1 < array.size(); n1++)
-  {
-    std::getline (file, line);
-
-    std::stringstream ss (line);
-
-    for (long n2 = 0; n2 < array[n1].size(); n2++)
-    {
-      ss >> array[n1][n2];
-    }
-  }
-
-  file.close();
-
-  return (0);
-}
-
-
-///  Writer for an array of doubles from a text file
-///    @param[in] file_name : path to file to be written
-///    @param[in] array     : array to be written
-////////////////////////////////////////////////////////
-int IoText :: write_array (const string file_name, const Double2 &array) const
-{
-  std::ofstream file (io_file + file_name + ".txt");
-
-  file << std::scientific << std::setprecision (16);
-
-  for (long n1 = 0; n1 < array.size(); n1++)
-  {
-    for (long n2 = 0; n2 < array[n1].size(); n2++)
-    {
-      file << array[n1][n2] << "\t";
-    }
-
-    file << endl;
-  }
-
-  file.close();
-
-  return (0);
-}
+// ///  Writer for an array of doubles from a text file
+// ///    @param[in] file_name : path to file to be written
+// ///    @param[in] array     : array to be written
+// ////////////////////////////////////////////////////////
+// int IoText :: write_array (const string file_name, const Double2 &array) const
+// {
+//   std::ofstream file (io_file + file_name + ".txt");
+//
+//   file << std::scientific << std::setprecision (16);
+//
+//   for (long n1 = 0; n1 < array.size(); n1++)
+//   {
+//     for (long n2 = 0; n2 < array[n1].size(); n2++)
+//     {
+//       file << array[n1][n2] << "\t";
+//     }
+//
+//     file << endl;
+//   }
+//
+//   file.close();
+//
+//   return (0);
+// }
 
 
 ///  Reader for an array of doubles from a text file

--- a/src/io/cpp/io_cpp_text.hpp
+++ b/src/io/cpp/io_cpp_text.hpp
@@ -37,8 +37,8 @@ struct IoText : public Io
     int  read_list     (const string fname,       Long1   &list  ) const override;
     int write_list     (const string fname, const Long1   &list  ) const override;
 
-    int  read_list     (const string fname,       Double1 &list  ) const override;
-    int write_list     (const string fname, const Double1 &list  ) const override;
+    // int  read_list     (const string fname,       Double1 &list  ) const override;
+    // int write_list     (const string fname, const Double1 &list  ) const override;
 
     int  read_list     (const string fname,       Size_t1 &list  ) const override;
     int write_list     (const string fname, const Size_t1 &list  ) const override;
@@ -55,8 +55,8 @@ struct IoText : public Io
     int  read_array    (const string fname,       Long2   &array ) const override;
     int write_array    (const string fname, const Long2   &array ) const override;
 
-    int  read_array    (const string fname,       Double2 &array ) const override;
-    int write_array    (const string fname, const Double2 &array ) const override;
+    // int  read_array    (const string fname,       Double2 &array ) const override;
+    // int write_array    (const string fname, const Double2 &array ) const override;
 
     int  read_array    (const string fname,       Real2   &array ) const override;
     int write_array    (const string fname, const Real2   &array ) const override;

--- a/src/io/io.hpp
+++ b/src/io/io.hpp
@@ -38,8 +38,8 @@ struct Io
     virtual int  read_list     (const string fname,       Long1   &list  ) const = 0;
     virtual int write_list     (const string fname, const Long1   &list  ) const = 0;
 
-    virtual int  read_list     (const string fname,       Double1 &list  ) const = 0;
-    virtual int write_list     (const string fname, const Double1 &list  ) const = 0;
+    // virtual int  read_list     (const string fname,       Double1 &list  ) const = 0;
+    // virtual int write_list     (const string fname, const Double1 &list  ) const = 0;
 
     virtual int  read_list     (const string fname,       Size_t1 &list  ) const = 0;
     virtual int write_list     (const string fname, const Size_t1 &list  ) const = 0;
@@ -56,8 +56,8 @@ struct Io
     virtual int  read_array    (const string fname,       Long2   &array ) const = 0;
     virtual int write_array    (const string fname, const Long2   &array ) const = 0;
 
-    virtual int  read_array    (const string fname,       Double2 &array ) const = 0;
-    virtual int write_array    (const string fname, const Double2 &array ) const = 0;
+    // virtual int  read_array    (const string fname,       Double2 &array ) const = 0;
+    // virtual int write_array    (const string fname, const Double2 &array ) const = 0;
 
     virtual int  read_array    (const string fname,       Real2   &array ) const = 0;
     virtual int write_array    (const string fname, const Real2   &array ) const = 0;

--- a/src/io/python/io_python.cpp
+++ b/src/io/python/io_python.cpp
@@ -206,31 +206,31 @@ int IoPython :: write_list (const string file_name, const Long1 &list) const
 }
 
 
-///  Reader for a list of doubles from a file
-///    @param[in] file_name : path to file containing the list
-///    @param[in] list      : list to be read
-//////////////////////////////////////////////////////////////
-int IoPython :: read_list (const string file_name, Double1 &list) const
-{
-    return read_in_python <Double1> ("read_array", file_name, list);
-}
+// ///  Reader for a list of doubles from a file
+// ///    @param[in] file_name : path to file containing the list
+// ///    @param[in] list      : list to be read
+// //////////////////////////////////////////////////////////////
+// int IoPython :: read_list (const string file_name, Double1 &list) const
+// {
+//     return read_in_python <Double1> ("read_array", file_name, list);
+// }
 
 
-///  Writer for a list of doubles to a file
-///    @param[in] file_name : path to file to be written
-///    @param[in] list      : list to be written
-////////////////////////////////////////////////////////
-int IoPython :: write_list (const string file_name, const Double1 &list) const
-{
-    int err = 0;
-
-    if (list.size() > 0)
-    {
-        err = write_in_python <Double1> ("write_array", file_name, list);
-    }
-
-    return err;
-}
+// ///  Writer for a list of doubles to a file
+// ///    @param[in] file_name : path to file to be written
+// ///    @param[in] list      : list to be written
+// ////////////////////////////////////////////////////////
+// int IoPython :: write_list (const string file_name, const Double1 &list) const
+// {
+//     int err = 0;
+//
+//     if (list.size() > 0)
+//     {
+//         err = write_in_python <Double1> ("write_array", file_name, list);
+//     }
+//
+//     return err;
+// }
 
 
 ///  Reader for a list of doubles from a file
@@ -368,31 +368,31 @@ int IoPython :: write_array (const string file_name, const Long2 &array) const
 }
 
 
-///  Reader for an array of doubles from a file
-///    @param[in] file_name : path to file containing the array
-///    @param[in] array     : array to be read
-///////////////////////////////////////////////////////////////
-int IoPython :: read_array (const string file_name, Double2 &array) const
-{
-    return read_in_python <Double2> ("read_array", file_name, array);
-}
+// ///  Reader for an array of doubles from a file
+// ///    @param[in] file_name : path to file containing the array
+// ///    @param[in] array     : array to be read
+// ///////////////////////////////////////////////////////////////
+// int IoPython :: read_array (const string file_name, Double2 &array) const
+// {
+//     return read_in_python <Double2> ("read_array", file_name, array);
+// }
 
 
-///  Writer for an array of doubles from a file
-///    @param[in] file_name : path to file to be written
-///    @param[in] array     : array to be written
-////////////////////////////////////////////////////////
-int IoPython :: write_array (const string file_name, const Double2 &array) const
-{
-    int err = 0;
-
-    if (array.size() > 0)
-    {
-        err = write_in_python <Double2> ("write_array", file_name, array);
-    }
-
-    return err;
-}
+// ///  Writer for an array of doubles from a file
+// ///    @param[in] file_name : path to file to be written
+// ///    @param[in] array     : array to be written
+// ////////////////////////////////////////////////////////
+// int IoPython :: write_array (const string file_name, const Double2 &array) const
+// {
+//     int err = 0;
+//
+//     if (array.size() > 0)
+//     {
+//         err = write_in_python <Double2> ("write_array", file_name, array);
+//     }
+//
+//     return err;
+// }
 
 
 ///  Reader for an array of doubles from a file

--- a/src/io/python/io_python.hpp
+++ b/src/io/python/io_python.hpp
@@ -40,8 +40,8 @@ struct IoPython : public Io
         int  read_list     (const string fname,       Long1   &list  ) const override;
         int write_list     (const string fname, const Long1   &list  ) const override;
 
-        int  read_list     (const string fname,       Double1 &list  ) const override;
-        int write_list     (const string fname, const Double1 &list  ) const override;
+        // int  read_list     (const string fname,       Double1 &list  ) const override;
+        // int write_list     (const string fname, const Double1 &list  ) const override;
 
         int  read_list     (const string fname,       Size_t1 &list  ) const override;
         int write_list     (const string fname, const Size_t1 &list  ) const override;
@@ -58,8 +58,8 @@ struct IoPython : public Io
         int  read_array    (const string fname,       Long2   &array ) const override;
         int write_array    (const string fname, const Long2   &array ) const override;
 
-        int  read_array    (const string fname,       Double2 &array ) const override;
-        int write_array    (const string fname, const Double2 &array ) const override;
+        // int  read_array    (const string fname,       Double2 &array ) const override;
+        // int write_array    (const string fname, const Double2 &array ) const override;
 
         int  read_array    (const string fname,       Real2   &array ) const override;
         int write_array    (const string fname, const Real2   &array ) const override;

--- a/src/tools/types.hpp
+++ b/src/tools/types.hpp
@@ -21,10 +21,12 @@ using std::sqrt;
 namespace pc = paracabs;
 
 // Default Real and Size types
-typedef long double Real;
+// typedef long double Real;
+typedef double Real;
 typedef uint32_t    Size;
 
-#define MPI_TYPE_REAL MPI_LONG_DOUBLE
+// #define MPI_TYPE_REAL MPI_LONG_DOUBLE
+#define MPI_TYPE_REAL MPI_DOUBLE
 #define MPI_TYPE_SIZE MPI_INT
 
 // Paracabs Vector3D


### PR DESCRIPTION
To do this some redundant io functions had to be commented out. Fancier macro stuff to avoid double overloading is possible, but not included.

Practically, the performance of Magritte doubles.
Is there actually any reason (except 'we didn't test it yet') why we did not yet make this change?