### PR TITLE
Fixed inconsistent number of rays defined in import phantom test.

### DIFF
--- a/tests/benchmarks/numeric/import_phantom_3D_model.py
+++ b/tests/benchmarks/numeric/import_phantom_3D_model.py
@@ -165,11 +165,11 @@ def import_phantom():
     model.parameters.set_nboundary(boundary.shape[0])
     model.geometry.boundary.boundary2point.set(boundary)
 
-    direction = np.array([[0,0,+1], [0,0,-1]])            # Comment out to use all directions
-    model.geometry.rays.direction.set(direction)          # Comment out to use all directions
-    model.geometry.rays.weight   .set(0.5 * np.ones(2))   # Comment out to use all directions
+    # direction = np.array([[0,0,+1], [0,0,-1]])            # Comment out to use all directions
+    # model.geometry.rays.direction.set(direction)          # Comment out to use all directions
+    # model.geometry.rays.weight   .set(0.5 * np.ones(2))   # Comment out to use all directions
 
-    # model = setup.set_uniform_rays            (model)   # Uncomment to use all directions
+    model = setup.set_uniform_rays            (model)   # Uncomment to use all directions
     model = setup.set_boundary_condition_CMB  (model)
     model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})
     # model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions


### PR DESCRIPTION
Should be able to fix some memory corruption issues when running the original large model. Note: the model itself is still quite large to run, so it is still not recommended to run on its own.
Note: in the CI pipeline, this changes nothing; but as this can be considered documentation (for which we guarantee it should work), it should be correct.