### PR TITLE
Added TEMPORARY workaround of setting xcode version to 14.1.

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -30,6 +30,12 @@ jobs:
       - name: install dependencies
         run: ${{matrix.PACKAGE_MANAGER}} ${{matrix.INSTALL_COMMAND}} ${{matrix.DEPENDENCIES}}
 
+      - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
+        if: matrix.os == 'macos-latest'
+        uses: maxim-lobanov/setup-xcode@v1.5.1
+        with:
+          xcode-version: '14.1' #version 14.1 should no longer have this bug
+
       # retrying checkout: 3 tries, with 5 seconds wait inbetween
       - name: Check out repository code (try 1)
         id: checkouttry1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,6 +48,12 @@ jobs:
       - name: install dependencies
         run: ${{matrix.PACKAGE_MANAGER}} ${{matrix.INSTALL_COMMAND}} ${{matrix.DEPENDENCIES}}
 
+      - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
+        if: matrix.os == 'macos-latest'
+        uses: maxim-lobanov/setup-xcode@v1.5.1
+        with:
+          xcode-version: '14.1' #version 14.1 should no longer have this bug
+
       # retrying checkout: 3 tries, with 5 seconds wait inbetween
       - name: Check out repository code (try 1)
         id: checkouttry1


### PR DESCRIPTION
Added action for specifying xcode version on macos.
We should ponder whether to add something to the documentation about this.
TODO: create issue for removing this workaround