### PR TITLE
Removed brew for downloading gmsh in automatic testing.

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -59,7 +59,7 @@ jobs:
       # end retrying checkout
       - name: install gmsh
         run: |
-          bash ./depdendencies/get_gmsh.sh
+          bash ./dependencies/get_gmsh.sh
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -62,6 +62,7 @@ jobs:
           bash ./dependencies/get_gmsh.sh
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
           echo $GITHUB_WORKSPACE
+          echo $GITHUB_PATH
           gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
 

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -60,7 +60,7 @@ jobs:
       - name: install gmsh
         run: |
           bash get_gmsh.sh
-          echo "${pwd}/gmsh/bin/" >> $GITHUB_PATH
+          echo "${PWD}/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
         working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -62,12 +62,9 @@ jobs:
         run: |
           bash ./dependencies/get_gmsh.sh
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
-          echo $GITHUB_WORKSPACE
-          echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/"
-          ls $GITHUB_WORKSPACE/dependencies/gmsh
-          ls $GITHUB_WORKSPACE/dependencies/gmsh/bin
         #err, relies a bit too much on absolute path for which the script install gmsh
-      - run: gmsh --version
+      - name: gmsh version
+        run: gmsh --version
 
       - name: setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -62,7 +62,8 @@ jobs:
           bash ./dependencies/get_gmsh.sh
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
           echo $GITHUB_WORKSPACE
-          echo $GITHUB_PATH
+          ls $GITHUB_WORKSPACE/dependencies/gmsh
+          ls $GITHUB_WORKSPACE/dependencies/gmsh/bin
           gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
 

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -60,7 +60,7 @@ jobs:
       - name: install gmsh
         run: |
           bash ./dependencies/get_gmsh.sh
-          echo ${pwd}/dependencies/gmsh/bin/ >> $GITHUB_PATH
+          echo "${pwd}/dependencies/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
 

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -11,24 +11,24 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            PACKAGE_MANAGER: brew
-            INSTALL_COMMAND: install
-            DEPENDENCIES: gmsh #llvm libomp
             C-COMPILER: gcc-11
             CXX-COMPILER: g++-11
           - os: ubuntu-latest
-            PACKAGE_MANAGER: sudo apt-get
-            INSTALL_COMMAND: install -y
-            DEPENDENCIES: gmsh libegl1
             C-COMPILER: gcc
             CXX-COMPILER: g++
     defaults:
       run:
         shell: bash -l {0} #necessary for conda
     steps:
-      - run: ${{matrix.PACKAGE_MANAGER}} update
-      - name: install dependencies
-        run: ${{matrix.PACKAGE_MANAGER}} ${{matrix.INSTALL_COMMAND}} ${{matrix.DEPENDENCIES}}
+      - name: (linux) install libegl1
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1
+      - name: install gmsh
+        run: |
+          bash ./dependencies/get_gmsh.sh
+          export PATH=${pwd}/gmsh/bin/:${PATH}
 
       - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -59,10 +59,9 @@ jobs:
       # end retrying checkout
       - name: install gmsh
         run: |
-          bash get_gmsh.sh
-          echo "$GITHUB_WORKSPACE/gmsh/bin/" >> $GITHUB_PATH
+          bash ./depdendencies/get_gmsh.sh
+          echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
-        working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -25,10 +25,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libegl1
-      - name: install gmsh
-        run: |
-          bash ./dependencies/get_gmsh.sh
-          export PATH=${pwd}/gmsh/bin/:${PATH}
 
       - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
         if: matrix.os == 'macos-latest'
@@ -61,6 +57,10 @@ jobs:
         with: #no ref: thus checks out commit which triggered workflow
           submodules: true
       # end retrying checkout
+      - name: install gmsh
+        run: |
+          bash ./dependencies/get_gmsh.sh
+          export PATH=${pwd}/gmsh/bin/:${PATH}
 
       - name: setup python
         uses: actions/setup-python@v3

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -60,7 +60,7 @@ jobs:
       - name: install gmsh
         run: |
           bash get_gmsh.sh
-          echo "${PWD}/gmsh/bin/" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
         working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -62,6 +62,7 @@ jobs:
           bash ./dependencies/get_gmsh.sh
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
           echo $GITHUB_WORKSPACE
+          echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/"
           ls $GITHUB_WORKSPACE/dependencies/gmsh
           ls $GITHUB_WORKSPACE/dependencies/gmsh/bin
           gmsh --version

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -59,9 +59,10 @@ jobs:
       # end retrying checkout
       - name: install gmsh
         run: |
-          bash ./dependencies/get_gmsh.sh
-          echo "${pwd}/dependencies/gmsh/bin/" >> $GITHUB_PATH
+          bash get_gmsh.sh
+          echo "${pwd}/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
+        working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           bash ./dependencies/get_gmsh.sh
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
+          echo $GITHUB_WORKSPACE
           gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
 

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -24,7 +24,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libegl1
+          sudo apt-get install -y libegl1 libglu1-mesa
+      #I think these dependencies are all required for gmsh; TODO: remove them after I remove gmsh
 
       - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -60,10 +60,11 @@ jobs:
       - name: install gmsh
         run: |
           bash ./dependencies/get_gmsh.sh
-          export PATH=${pwd}/gmsh/bin/:${PATH}
+          export PATH=${pwd}/dependencies/gmsh/bin/:${PATH}
+        #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
 
       # retrying setting up conda: 3 tries, with 5 seconds wait inbetween
       - name: Install conda packages (try 1)

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -65,8 +65,8 @@ jobs:
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/"
           ls $GITHUB_WORKSPACE/dependencies/gmsh
           ls $GITHUB_WORKSPACE/dependencies/gmsh/bin
-          gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
+      - run: gmsh --version
 
       - name: setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -60,7 +60,8 @@ jobs:
       - name: install gmsh
         run: |
           bash ./dependencies/get_gmsh.sh
-          export PATH=${pwd}/dependencies/gmsh/bin/:${PATH}
+          echo ${pwd}/dependencies/gmsh/bin/ >> $GITHUB_PATH
+          gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,6 +81,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
+      - run: gmsh --version
 
       - name: setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libegl1
+          sudo apt-get install -y libegl1 libglu1-mesa
+      #I think these dependencies are all required for gmsh; TODO: remove them after I remove gmsh
 
       - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,9 +78,9 @@ jobs:
       - name: install gmsh
         run: |
           bash ./get_gmsh.sh
-          echo "${PWD}/gmsh/bin/" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
-          working-directory: dependencies
+        working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,10 +77,9 @@ jobs:
       # end retrying checkout
       - name: install gmsh
         run: |
-          bash ./get_gmsh.sh
-          echo "$GITHUB_WORKSPACE/gmsh/bin/" >> $GITHUB_PATH
+          bash ./dependencies/get_gmsh.sh
+          echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
-        working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,10 +78,11 @@ jobs:
       - name: install gmsh
         run: |
           bash ./dependencies/get_gmsh.sh
-          export PATH=${pwd}/gmsh/bin/:${PATH}
+          export PATH=${pwd}/dependencies/gmsh/bin/:${PATH}
+        #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
 
       # retrying setting up conda: 3 tries, with 5 seconds wait inbetween
       - name: Install conda packages (try 1)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,7 +78,7 @@ jobs:
       - name: install gmsh
         run: |
           bash ./get_gmsh.sh
-          echo "${pwd}/gmsh/bin/" >> $GITHUB_PATH
+          echo "${PWD}/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
           working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,7 +78,8 @@ jobs:
       - name: install gmsh
         run: |
           bash ./dependencies/get_gmsh.sh
-          export PATH=${pwd}/dependencies/gmsh/bin/:${PATH}
+          echo ${pwd}/dependencies/gmsh/bin/ >> $GITHUB_PATH
+          gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,11 +43,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libegl1
-      - name: install gmsh
-        run: |
-          bash ./dependencies/get_gmsh.sh
-          export PATH=${pwd}/gmsh/bin/:${PATH}
-      
+
       - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
         if: matrix.os == 'macos-latest'
         uses: maxim-lobanov/setup-xcode@v1.5.1
@@ -79,6 +75,10 @@ jobs:
         with: #no ref: thus checks out commit which triggered workflow
           submodules: true
       # end retrying checkout
+      - name: install gmsh
+        run: |
+          bash ./dependencies/get_gmsh.sh
+          export PATH=${pwd}/gmsh/bin/:${PATH}
 
       - name: setup python
         uses: actions/setup-python@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,25 +29,25 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            PACKAGE_MANAGER: brew
-            INSTALL_COMMAND: install
-            DEPENDENCIES: gmsh #llvm libomp
             C-COMPILER: gcc-11
             CXX-COMPILER: g++-11
           - os: ubuntu-latest
-            PACKAGE_MANAGER: sudo apt-get
-            INSTALL_COMMAND: install -y
-            DEPENDENCIES: gmsh libegl1
             C-COMPILER: gcc
             CXX-COMPILER: g++
     defaults:
       run:
         shell: bash -l {0} # necessary for conda
     steps:
-      - run: ${{matrix.PACKAGE_MANAGER}} update
-      - name: install dependencies
-        run: ${{matrix.PACKAGE_MANAGER}} ${{matrix.INSTALL_COMMAND}} ${{matrix.DEPENDENCIES}}
-
+      - name: (linux) install libegl1
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1
+      - name: install gmsh
+        run: |
+          bash ./dependencies/get_gmsh.sh
+          export PATH=${pwd}/gmsh/bin/:${PATH}
+      
       - name: (temporary fix) set xcode version to latest  #due to xcode 14.0 being bugged, some issue with the linker exists when compiling
         if: matrix.os == 'macos-latest'
         uses: maxim-lobanov/setup-xcode@v1.5.1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,9 +77,10 @@ jobs:
       # end retrying checkout
       - name: install gmsh
         run: |
-          bash ./dependencies/get_gmsh.sh
-          echo "${pwd}/dependencies/gmsh/bin/" >> $GITHUB_PATH
+          bash ./get_gmsh.sh
+          echo "${pwd}/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
+          working-directory: dependencies
         #err, relies a bit too much on absolute path for which the script install gmsh
 
       - name: setup python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,9 +80,9 @@ jobs:
         run: |
           bash ./dependencies/get_gmsh.sh
           echo "$GITHUB_WORKSPACE/dependencies/gmsh/bin/" >> $GITHUB_PATH
-          gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
-      - run: gmsh --version
+      - name: gsmh version
+        run: gmsh --version
 
       - name: setup python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,7 +78,7 @@ jobs:
       - name: install gmsh
         run: |
           bash ./dependencies/get_gmsh.sh
-          echo ${pwd}/dependencies/gmsh/bin/ >> $GITHUB_PATH
+          echo "${pwd}/dependencies/gmsh/bin/" >> $GITHUB_PATH
           gmsh --version
         #err, relies a bit too much on absolute path for which the script install gmsh
 

--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.9
   - cmake
   - k3d
-  - numpy
+  - numpy=1.23 #Temporary error with numba calling numpy calling ufunc with no exceptions in latest numpy; see https://github.com/numba/numba/issues/8615
   - vtk
   - jupyterlab
   - yt


### PR DESCRIPTION
As brew currently disagrees with github about linker errors (and the we already have a download script for gmsh), we will download gmsh directly instead.