### PR TITLE
Loosen numpy requirement for conda environment.

### DIFF
--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.9
   - cmake
   - k3d
-  - numpy=1.23 #Temporary error with numba calling numpy calling ufunc with no exceptions in latest numpy; see https://github.com/numba/numba/issues/8615
+  - numpy<=1.23 #Temporary error with numba calling numpy calling ufunc with no exceptions in latest numpy; see https://github.com/numba/numba/issues/8615
   - vtk
   - jupyterlab
   - yt


### PR DESCRIPTION
Err, the too strict numpy requirement seems to have broken the CI setup, loosening for now.