### PR TITLE
CI mamba issue workaround

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -77,7 +77,7 @@ jobs:
           activate-environment: magritte
           environment-file: dependencies/conda_env.yml
           auto-activate-base: false
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge, defaults
       - name: wait 5 s if attempt failed
         if: steps.setupcondatry1.outcome == 'failure'
@@ -90,7 +90,7 @@ jobs:
           activate-environment: magritte
           environment-file: dependencies/conda_env.yml
           auto-activate-base: false
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge, defaults
       - name: wait 5 s if attempt failed
         if: steps.setupcondatry2.outcome == 'failure'
@@ -103,7 +103,7 @@ jobs:
           activate-environment: magritte
           environment-file: dependencies/conda_env.yml
           auto-activate-base: false
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge, defaults
       # end retrying conda
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -95,7 +95,7 @@ jobs:
           activate-environment: magritte
           environment-file: dependencies/conda_env.yml
           auto-activate-base: false
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge, defaults
       - name: wait 5 s if attempt failed
         if: steps.setupcondatry1.outcome == 'failure'
@@ -108,7 +108,7 @@ jobs:
           activate-environment: magritte
           environment-file: dependencies/conda_env.yml
           auto-activate-base: false
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge, defaults
       - name: wait 5 s if attempt failed
         if: steps.setupcondatry2.outcome == 'failure'
@@ -121,7 +121,7 @@ jobs:
           activate-environment: magritte
           environment-file: dependencies/conda_env.yml
           auto-activate-base: false
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
           channels: conda-forge, defaults
       # end retrying conda
 


### PR DESCRIPTION
According to https://github.com/conda-incubator/setup-miniconda/issues/274, specifying another miniforge variant should be a valid workaround.