### PR TITLE
Improve documentation

### DIFF
--- a/docs/src/0_getting_started/3_updating_Magritte.rst
+++ b/docs/src/0_getting_started/3_updating_Magritte.rst
@@ -1,0 +1,40 @@
+.. _link-updating_Magritte:
+
+Updating Magritte
+#################
+
+This part of the documentation assumes that one has a previous version of magritte installed
+and the core (non-python, non-submodule) dependencies of Magritte did not change. Otherwise, check out the :ref:`prerequisites <link-prerequisites>`.
+
+Pull
+****
+
+To get the latest magritte version, we pull from the repository, including all submodules.
+
+.. code-block:: shell
+
+    git pull --recurse-submodule
+
+
+Update dependencies
+*******************
+
+We update the conda environment, as the python dependencies might have changed.
+
+.. code-block:: shell
+
+    conda activate magritte
+    conda env update -f dependencies/conda_env.yml
+
+
+Build
+*****
+
+Magritte can be build using its default configuration.
+
+.. code-block:: shell
+
+    bash build.sh
+
+
+The latest version of magritte is now installed on your machine.

--- a/docs/src/0_getting_started/index.rst
+++ b/docs/src/0_getting_started/index.rst
@@ -1,8 +1,8 @@
 Getting started
 ###############
 
-First check if all :ref:`prerequisites <link-prerequisites>` are in place before continuing to install Magritte in the :ref:`quickstart <link-prerequisites>`.
-More background on the installation process of Magritte can be found in the :ref:`installation <link-installation>` notes.
+First check if all :ref:`prerequisites <link-prerequisites>` are in place before continuing to install Magritte in the :ref:`quickstart <link-quickstart>`.
+More background on the installation process of Magritte can be found in the :ref:`installation <link-installation>` notes. For returning users, we refer to the quick guide on :ref:`updating Magritte <link-updating_Magritte>`.
 
 .. toctree::
    :maxdepth: 2
@@ -11,3 +11,4 @@ More background on the installation process of Magritte can be found in the :ref
    0_prerequisites
    1_quickstart
    2_installation
+   3_updating_Magritte

--- a/docs/src/1_examples/index.rst
+++ b/docs/src/1_examples/index.rst
@@ -5,6 +5,7 @@ Examples
 ########
 
 The following examples demonstrate how to use Magritte as a Python library.
+The corresponding jupyter notebooks can be found in the source code at :code:`docs/src/1_examples/`.
 
 .. Please refer to the :ref:`C++ API documentation <link-cpp_api_documentation>`
 .. to see how Magritte can be used as a C++ library.
@@ -13,7 +14,7 @@ The following examples demonstrate how to use Magritte as a Python library.
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
-   
+
    0_creating_models/index
    1_post-processing/index
    2_synthetic_observations/index


### PR DESCRIPTION
As we (hopefully) get more users, shortcoming in the documentation is noted:
- We should explicitly state that the example notebooks are part of the documentation and can be run.
- We might need to add some instructions on how to update magritte.