### PR TITLE
Reduced memory cost of plot_mpl

### DIFF
--- a/magritte/plot.py
+++ b/magritte/plot.py
@@ -104,7 +104,6 @@ def image_mpl(
     imx = np.array(model.images[image_nr].ImX)
     imy = np.array(model.images[image_nr].ImY)
     imI = np.array(model.images[image_nr].I)
-    imv = np.array(model.radiation.frequencies.nu)[0]
 
     # Workaround for model images
     if (model.images[image_nr].imagePointPosition == ImagePointPosition.AllModelPoints):
@@ -285,7 +284,6 @@ def image_plotly(
     imx = np.array(model.images[image_nr].ImX)
     imy = np.array(model.images[image_nr].ImY)
     imI = np.array(model.images[image_nr].I)
-    imv = np.array(model.radiation.frequencies.nu)[0]
 
     # Workaround for model images
     if (model.images[image_nr].imagePointPosition == ImagePointPosition.AllModelPoints):


### PR DESCRIPTION
We were accidentally trying to copy all frequencies of the model in order to compute the frequency discretization of the image. This is no longer necessary, as of #185.