### PR TITLE
Unpinned numpy version in conda env file

### DIFF
--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.9
   - cmake
   - k3d
-  - numpy=1.23 #Temporary error with numba calling numpy calling ufunc with no exceptions in latest numpy; see https://github.com/numba/numba/issues/8615
+  - numpy
   - vtk
   - jupyterlab
   - yt


### PR DESCRIPTION
Due to issues with numba, the numpy version had been pinned.
By now, these issues should be resolved, so I am unpinning numpy again.