### PR TITLE
83 use astroquery to read lamda files

### DIFF
--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -23,7 +23,7 @@ dependencies:
   - h5py
   - numba
   - healpy
-  - astropy
+  - astroquery
   - jupyterlab-plotly-extension
   - nbdime
   - jupyterlab-git

--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -23,6 +23,7 @@ dependencies:
   - h5py
   - numba
   - healpy
+  - astropy
   - jupyterlab-plotly-extension
   - nbdime
   - jupyterlab-git

--- a/tests/benchmarks/analytic/reject_nonexistent_species.py
+++ b/tests/benchmarks/analytic/reject_nonexistent_species.py
@@ -1,0 +1,68 @@
+#Test file: forgetting to specify the species of the lamda file in the list of chemical species should result in an error being raised
+import os
+
+curdir = os.path.dirname(os.path.realpath(__file__))
+datdir = f'{curdir}/../../data/'
+moddir = f'{curdir}/../../models/'
+resdir = f'{curdir}/../../results/'
+
+import numpy             as np
+import magritte.setup    as setup
+import magritte.core     as magritte
+
+
+dimension = 1
+npoints   = 50
+nrays     = 2
+nspecs    = 5
+nlspecs   = 1
+nquads    = 1
+
+nH2  = 1.0E+12                 # [m^-3]
+nTT  = 1.0E+03                 # [m^-3]
+temp = 4.5E+00                 # [K]
+turb = 0.0E+00                 # [m/s]
+dx   = 1.0E+12                 # [m]
+dv   = 0.0E+00 / magritte.CC   # [fraction of speed of light]
+
+
+def create_model ():
+    """
+    Create a model file for the all_constant benchmark, single ray.
+    """
+
+    modelName = f'all_constant_single_ray'
+    modelFile = f'{moddir}{modelName}.hdf5'
+    lamdaFile = f'{datdir}test.txt'
+
+
+    model = magritte.Model ()
+    model.parameters.set_spherical_symmetry(False)
+    model.parameters.set_model_name        (modelFile)
+    model.parameters.set_dimension         (dimension)
+    model.parameters.set_npoints           (npoints)
+    model.parameters.set_nrays             (nrays)
+    model.parameters.set_nspecs            (nspecs)
+    model.parameters.set_nlspecs           (nlspecs)
+    model.parameters.set_nquads            (nquads)
+
+    model.geometry.points.position.set([[i*dx, 0, 0] for i in range(npoints)])
+    model.geometry.points.velocity.set([[i*dv, 0, 0] for i in range(npoints)])
+
+    model.chemistry.species.abundance = [[     0.0,    nTT,  nH2,  0.0,      1.0] for _ in range(npoints)]
+    model.chemistry.species.symbol    =  ['dummy0', 'This name does not correspond with the species name in test.txt', 'H2', 'e-', 'dummy1']
+
+    model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
+    model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
+
+    model = setup.set_Delaunay_neighbor_lists (model)
+    model = setup.set_Delaunay_boundary       (model)
+    model = setup.set_boundary_condition_CMB  (model)
+    model = setup.set_uniform_rays            (model)
+    #The next line should throw an error, as we expect the list of chemical species to contain the name of the species we are reading in ('test').
+    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    model = setup.set_quadrature              (model)
+
+    model.write()
+
+    return #magritte.Model (modelFile)

--- a/tests/benchmarks/analytic/test_benchmarks.py
+++ b/tests/benchmarks/analytic/test_benchmarks.py
@@ -1,3 +1,4 @@
+from reject_nonexistent_species import create_model as reject_nonexistent_species_setup
 from all_constant_single_ray import create_model as all_constant_setup
 from all_constant_single_ray import run_model as all_constant_run
 from all_zero_single_ray import create_model as all_zero_setup
@@ -29,6 +30,10 @@ class TestInput:
             bogusFile = "dlpbmfhqbzeszvroptsqwupklhbtvkzkmebzdduhetthdjakgz.hdf5"
             model = magritte.Model(bogusFile) #reading bogus files should raise an exception
             #note: if we segfault, pytest will also complain, so this should protect against segfaults
+
+    def test_read_nonexistent_species(self):
+        with pytest.raises(Exception):
+            reject_nonexistent_species_setup()
 
 class TestAnalytic:
     #incremental testing; see conftest.py or pytest.ini


### PR DESCRIPTION
By using astroquery for its lamda module, reading in the files should be more robust (as that subroutine actually fully adheres to the lamda file spec).