### PR TITLE
Fixed bug in NLTE radiative transfer

### DIFF
--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -291,8 +291,9 @@ PYBIND11_MODULE(core, module) {
         .def_readwrite("pop_prec", &Parameters::pop_prec, "Required precision for ALI.")
         .def_readwrite("min_opacity", &Parameters::min_opacity,
             "Minimum opacity that will be assumed in the solver.")
-        .def_readwrite("min_line_opacity", &Parameters::min_line_opacity,
-            "Minimum line opacity that will be assumed in the solver.")
+        .def_readwrite("min_emissivity", &Parameters::min_emissivity,
+            "Value for emissivity that will be used when the minimum opacity is used in the "
+            "solver.")
         .def_readwrite("min_dtau", &Parameters::min_dtau,
             "Minimum optical depth increment that will be assumed in the solver.")
         .def_readwrite("store_intensities", &Parameters::store_intensities,

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -296,6 +296,9 @@ PYBIND11_MODULE(core, module) {
             "solver.")
         .def_readwrite("min_dtau", &Parameters::min_dtau,
             "Minimum optical depth increment that will be assumed in the solver.")
+        .def_readwrite("min_line_opacity", &Parameters::min_line_opacity,
+            "Minimum line opacity that will be assumed in the solver. Used when large velocity "
+            "gradients are present.")
         .def_readwrite("store_intensities", &Parameters::store_intensities,
             "Whether or not to store intensities.")
         .def_readwrite("one_line_approximation", &Parameters::one_line_approximation,

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -291,6 +291,8 @@ PYBIND11_MODULE(core, module) {
         .def_readwrite("pop_prec", &Parameters::pop_prec, "Required precision for ALI.")
         .def_readwrite("min_opacity", &Parameters::min_opacity,
             "Minimum opacity that will be assumed in the solver.")
+        .def_readwrite("min_line_opacity", &Parameters::min_line_opacity,
+            "Minimum line opacity that will be assumed in the solver.")
         .def_readwrite("min_dtau", &Parameters::min_dtau,
             "Minimum optical depth increment that will be assumed in the solver.")
         .def_readwrite("store_intensities", &Parameters::store_intensities,

--- a/src/model/lines/lines.tpp
+++ b/src/model/lines/lines.tpp
@@ -37,6 +37,29 @@ inline void Lines ::set_emissivity_and_opacity() {
             }
         }
     })
+
+    Real min_opacity = opacity.min();
+    if (min_opacity < parameters->line_opacity_warning_threshold) {
+        cout << "Warning: Significant negative line opacity detected. Magritte does not handle "
+                "masers and will ignore this. Minimum line opacity in the model: "
+             << min_opacity << " [m^-1 Hz]" << endl;
+    } else if (min_opacity < 0) {
+        cout << "Minor warning: Negative opacity detected. This can be a numerical error, and will "
+                "be ignored by Magritte."
+             << endl;
+    }
+    // Now also setting the opacity to the minimum allowed value
+    threaded_for(p, parameters->npoints(), {
+        for (Size l = 0; l < parameters->nlspecs(); l++) {
+            for (Size k = 0; k < lineProducingSpecies[l].linedata.nrad; k++) {
+                const Size lid = line_index(l, k);
+
+                if (opacity(p, lid) < parameters->min_line_opacity) {
+                    opacity(p, lid) = parameters->min_line_opacity;
+                }
+            }
+        }
+    })
 }
 
 ///  Setter for line widths

--- a/src/model/lines/lines.tpp
+++ b/src/model/lines/lines.tpp
@@ -49,17 +49,17 @@ inline void Lines ::set_emissivity_and_opacity() {
              << endl;
     }
     // Now also setting the opacity to the minimum allowed value
-    threaded_for(p, parameters->npoints(), {
-        for (Size l = 0; l < parameters->nlspecs(); l++) {
-            for (Size k = 0; k < lineProducingSpecies[l].linedata.nrad; k++) {
-                const Size lid = line_index(l, k);
+    // threaded_for(p, parameters->npoints(), {
+    //     for (Size l = 0; l < parameters->nlspecs(); l++) {
+    //         for (Size k = 0; k < lineProducingSpecies[l].linedata.nrad; k++) {
+    //             const Size lid = line_index(l, k);
 
-                if (opacity(p, lid) < parameters->min_line_opacity) {
-                    opacity(p, lid) = parameters->min_line_opacity;
-                }
-            }
-        }
-    })
+    //             if (opacity(p, lid) < parameters->min_line_opacity) {
+    //                 opacity(p, lid) = parameters->min_line_opacity;
+    //             }
+    //         }
+    //     }
+    // })
 }
 
 ///  Setter for line widths

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -77,7 +77,8 @@ struct Parameters {
     Real min_rel_pop_for_convergence = 1.0e-10;
     Real pop_prec                    = 1.0e-6;
     Real min_opacity      = 1.0e-26; // mimimum allowed evaluated opacity [m^-1], must be positive
-    Real min_line_opacity = 1.0e-35; // minimum allowed line opacity, divided by the line frequency [m^-1], must be positive
+    Real min_line_opacity = 1.0e-35; // minimum allowed line opacity, divided by the line frequency
+                                     // [m^-1], must be positive
     Real line_opacity_warning_threshold =
         -1.0e-18; // If the opacity of a line is below this threshold, a warning is printed, as
                   // Magritte does not handle masers and ignores negative opacities

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -76,9 +76,13 @@ struct Parameters {
     Real convergence_fraction        = 0.995;
     Real min_rel_pop_for_convergence = 1.0e-10;
     Real pop_prec                    = 1.0e-6;
-    Real min_opacity                 = 1.0e-26;
-    Real min_dtau                    = 1.0e-15;
-    bool store_intensities           = false;
+    Real min_opacity      = 1.0e-26; // mimimum allowed evaluated opacity [m^-1], must be positive
+    Real min_line_opacity = 1.0e-20; // minimum allowed line opacity [m^-1 Hz], must be positive
+    Real line_opacity_warning_threshold =
+        -1.0e-18; // If the opacity of a line is below this threshold, a warning is printed, as
+                  // Magritte does not handle masers and ignores negative opacities
+    Real min_dtau          = 1.0e-15;
+    bool store_intensities = false;
     // bool use_Ng_acceleration         = true;//Not used,
     // so may safely be removed
     bool use_adaptive_Ng_acceleration = true;    // whether to use an adaptive version of Ng

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -77,7 +77,7 @@ struct Parameters {
     Real min_rel_pop_for_convergence = 1.0e-10;
     Real pop_prec                    = 1.0e-6;
     Real min_opacity      = 1.0e-26; // mimimum allowed evaluated opacity [m^-1], must be positive
-    Real min_line_opacity = 1.0e-20; // minimum allowed line opacity [m^-1 Hz], must be positive
+    Real min_line_opacity = 1.0e-35; // minimum allowed line opacity, divided by the line frequency [m^-1], must be positive
     Real line_opacity_warning_threshold =
         -1.0e-18; // If the opacity of a line is below this threshold, a warning is printed, as
                   // Magritte does not handle masers and ignores negative opacities

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -76,6 +76,8 @@ struct Parameters {
     Real convergence_fraction        = 0.995;
     Real min_rel_pop_for_convergence = 1.0e-10;
     Real pop_prec                    = 1.0e-6;
+    Real min_line_opacity            = 1.0e-30; // mimimum allowed evaluated opacity [m^-1 Hz^-1],
+                                                // must be positive
     Real min_opacity    = 1.0e-26; // mimimum allowed evaluated opacity [m^-1], must be positive
     Real min_emissivity = 1.0e-46; // minimum allowed evaluated emissivity [W sr^-1 m^-3 Hz^-1],
                                    // must be must be positive

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -76,9 +76,12 @@ struct Parameters {
     Real convergence_fraction        = 0.995;
     Real min_rel_pop_for_convergence = 1.0e-10;
     Real pop_prec                    = 1.0e-6;
-    Real min_opacity      = 1.0e-26; // mimimum allowed evaluated opacity [m^-1], must be positive
-    Real min_line_opacity = 1.0e-35; // minimum allowed line opacity, divided by the line frequency
-                                     // [m^-1], must be positive
+    Real min_opacity    = 1.0e-26; // mimimum allowed evaluated opacity [m^-1], must be positive
+    Real min_emissivity = 1.0e-46; // minimum allowed evaluated emissivity [W sr^-1 m^-3 Hz^-1],
+                                   // must be must be positive
+    // Please note that the previous two parameters should be set together, as the ratio
+    // emissivity/opacity will define the 'default' source function
+
     Real line_opacity_warning_threshold =
         -1.0e-18; // If the opacity of a line is below this threshold, a warning is printed, as
                   // Magritte does not handle masers and ignores negative opacities

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -120,6 +120,9 @@ struct Solver {
     inline Real compute_dtau_single_line(Model& model, Size curridx, Size nextidx, Size lineidx,
         Real curr_freq, Real next_freq, Real dz);
 
+    inline void compute_S_dtau_single_line(Model& model, Size curridx, Size nextidx, Size lineidx,
+        Real curr_freq, Real next_freq, Real dz, Real& Scurr, Real& Snext, Real& dtau);
+
     template <ApproximationType approx>
     accel inline void compute_source_dtau(Model& model, Size currpoint, Size nextpoint, Size line,
         Real curr_freq, Real next_freq, double curr_shift, double next_shift, Real dZ,

--- a/src/solver/solver.tpp
+++ b/src/solver/solver.tpp
@@ -1800,7 +1800,7 @@ accel inline void Solver ::compute_source_dtau(Model& model, Size currpoint, Siz
         Snext = eta_n / chinext;
 
         dtaunext = half * (chicurr + chinext) * dZ;
-            }
+    }
 }
 
 ///  Solver for Feautrier equation along ray pairs using the

--- a/src/solver/solver.tpp
+++ b/src/solver/solver.tpp
@@ -1012,7 +1012,7 @@ accel inline void Solver ::get_eta_and_chi<None>(const Model& model, const Size 
     const Real freq, Real& eta, Real& chi) const {
     // Initialize
     eta = 0.0;
-    chi = model.parameters->min_opacity;
+    chi = 0.0;
 
     // Set line emissivity and opacity
     for (Size l = 0; l < model.parameters->nlines(); l++) {
@@ -1022,6 +1022,7 @@ accel inline void Solver ::get_eta_and_chi<None>(const Model& model, const Size 
         eta += prof * model.lines.emissivity(p, l);
         chi += prof * model.lines.opacity(p, l);
     }
+    chi = std::max(chi, model.parameters->min_opacity);
 }
 
 ///  Getter for the emissivity (eta) and the opacity (chi)
@@ -1039,7 +1040,7 @@ accel inline void Solver ::get_eta_and_chi<CloseLines>(const Model& model, const
     const Real freq, Real& eta, Real& chi) const {
     // Initialize
     eta = 0.0;
-    chi = model.parameters->min_opacity;
+    chi = 0.0;
 
     const Real upper_bound_line_width =
         model.parameters->max_distance_opacity_contribution
@@ -1067,6 +1068,7 @@ accel inline void Solver ::get_eta_and_chi<CloseLines>(const Model& model, const
         eta += prof * model.lines.emissivity(p, l);
         chi += prof * model.lines.opacity(p, l);
     }
+    chi = std::max(chi, model.parameters->min_opacity);
 }
 
 ///  Getter for the emissivity (eta) and the opacity (chi)
@@ -1086,7 +1088,7 @@ accel inline void Solver ::get_eta_and_chi<OneLine>(
     const Real prof = freq * gaussian(model.lines.inverse_width(p, l), diff);
 
     eta = prof * model.lines.emissivity(p, l);
-    chi = prof * model.lines.opacity(p, l) + model.parameters->min_opacity;
+    chi = std::max(prof * model.lines.opacity(p, l), model.parameters->min_opacity);
 }
 
 ///  Apply trapezium rule to x_crt and x_nxt
@@ -1798,7 +1800,7 @@ accel inline void Solver ::compute_source_dtau(Model& model, Size currpoint, Siz
         Snext = eta_n / chinext;
 
         dtaunext = half * (chicurr + chinext) * dZ;
-    }
+            }
 }
 
 ///  Solver for Feautrier equation along ray pairs using the
@@ -2001,7 +2003,7 @@ inline Real Solver ::compute_dtau_single_line(Model& model, Size curridx, Size n
         const Real prof            = gaussian(average_inverse_line_width, diff);
         const Real average_opacity = (curr_line_opacity + next_line_opacity) / 2.0;
 
-        return dz * (prof * average_opacity + model.parameters->min_opacity);
+        return dz * std::max(prof * average_opacity, model.parameters->min_opacity);
     }
 
     // We assume a linear interpolation of these dimensionless
@@ -2048,7 +2050,7 @@ inline Real Solver ::compute_dtau_single_line(Model& model, Size curridx, Size n
     // correcting to bound opacity from below to the minimum
     // opacity (assumes positive opacities occuring in the
     // model)
-    return dz * (average_inverse_line_width * erfterm + model.parameters->min_opacity);
+    return dz * std::max(average_inverse_line_width * erfterm, model.parameters->min_opacity);
 }
 
 ///  Solver for Feautrier equation along ray pairs using the


### PR DESCRIPTION
In lower density regimes, population inversionsmight occur. If this happens, the opacity will become negative, leading to negative source functions and optical depths. The Feautrier solver cannot handle this. This is why we bound the opacities from below.

The actual change is just bounding the line opacities at the correct place in the code (+adding an extra parameter for bounding the line opacity and adding warnings when the line opacity becomes negative). 