### PR TITLE
Set maser lines to lte

### DIFF
--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -293,6 +293,9 @@ PYBIND11_MODULE(core, module) {
             "Minimum opacity that will be assumed in the solver.")
         .def_readwrite("min_dtau", &Parameters::min_dtau,
             "Minimum optical depth increment that will be assumed in the solver.")
+        .def_readwrite("population_inversion_fraction", &Parameters::population_inversion_fraction,
+            "Threshold factor for population inversion required for LTE to be used; set this "
+            "higher than 1")
         .def_readwrite("store_intensities", &Parameters::store_intensities,
             "Whether or not to store intensities.")
         .def_readwrite("one_line_approximation", &Parameters::one_line_approximation,

--- a/src/model/lines/lineProducingSpecies/lineProducingSpecies.hpp
+++ b/src/model/lines/lineProducingSpecies/lineProducingSpecies.hpp
@@ -80,6 +80,8 @@ struct LineProducingSpecies {
     inline void check_for_convergence_trial(const Real pop_prec);
 
     inline void update_using_LTE(const Double2& abundance, const Vector<Real>& temperature);
+    inline void set_LTE(
+        const Double2& abundance, const Vector<Real>& temperature, const Size p, const Size k);
 
     inline void update_using_statistical_equilibrium(
         const Double2& abundance, const Vector<Real>& temperature);
@@ -90,7 +92,8 @@ struct LineProducingSpecies {
     inline void update_using_Ng_acceleration();
     inline void update_using_acceleration(const Size order);
     inline void update_using_acceleration_trial(const Size order);
-    inline void correct_negative_populations();
+    inline void correct_negative_populations(
+        const Double2& abundance, const Vector<Real>& temperature);
 };
 
 #include "lineProducingSpecies.tpp"

--- a/src/model/lines/lineProducingSpecies/lineProducingSpecies.tpp
+++ b/src/model/lines/lineProducingSpecies/lineProducingSpecies.tpp
@@ -69,6 +69,44 @@ inline void LineProducingSpecies ::update_using_LTE(
     populations.push_back(population);
 }
 
+///  Set a single species, at a given point to LTE
+///    @param[in] p: number of cell
+///    @param[in] k: number of line
+/// Note: do call this from back to front in the loop over k, as otherwise new population inversions
+/// might occur
+///////////////////////////////////////////////////////////
+inline void LineProducingSpecies ::set_LTE(
+    const Double2& abundance, const Vector<Real>& temperature, const Size p, const Size k) {
+    // population_tot[p] = abundance[p][linedata.num];
+    const Size i = index(p, linedata.irad[k]);
+    const Size j = index(p, linedata.jrad[k]);
+
+    Real population_tot_line = population(i) + population(j);
+    Real partition_function  = 0.0;
+
+    population(i) = linedata.weight[linedata.irad[k]]
+                  * exp(-linedata.energy[linedata.irad[k]] / (KB * temperature[p]));
+    population(j) = linedata.weight[linedata.jrad[k]]
+                  * exp(-linedata.energy[linedata.jrad[k]] / (KB * temperature[p]));
+    partition_function = population(i) + population(j);
+    population(i) *= population_tot_line / partition_function;
+    population(j) *= population_tot_line / partition_function;
+
+    // for (Size i = 0; i < linedata.nlev; i++) {
+    //     const Size ind = index(p, i);
+
+    //     population(ind) = linedata.weight[i] * exp(-linedata.energy[i] / (KB * temperature[p]));
+
+    //     partition_function += population(ind);
+    // }
+
+    // for (Size i = 0; i < linedata.nlev; i++) {
+    //     const Size ind = index(p, i);
+
+    //     population(ind) *= population_tot_line / partition_function;
+    // }
+}
+
 /// This function check whether the level populations have converged, using the
 /// specified precision
 inline void LineProducingSpecies ::check_for_convergence(const Real pop_prec) {
@@ -652,7 +690,8 @@ inline void LineProducingSpecies::update_using_statistical_equilibrium_sparse(
 ///  renormalizes the other populations As numerical issues can cause negative populations, this
 ///  function corrects for this. It should therefore be called after each level population
 ///  determination
-inline void LineProducingSpecies::correct_negative_populations() {
+inline void LineProducingSpecies::correct_negative_populations(
+    const Double2& abundance, const Vector<Real>& temperature) {
     threaded_for(p, parameters->npoints(), {
         if (population_tot[p] > 0.0) {
             Real total_positive_population = 0.0;
@@ -672,4 +711,26 @@ inline void LineProducingSpecies::correct_negative_populations() {
             }
         }
     });
+
+    bool population_inversions = false;
+    // Also check if some population inversions (negative opacities) are present; set these points
+    // to LTE instead
+    threaded_for(p, parameters->npoints(), {
+        for (Size k = linedata.nrad - 1; k != static_cast<Size>(-1);
+             --k) { // reversed loop, stops at 0
+            // for (Size k = 0; k < linedata.nrad; k++) {
+            if (get_opacity(p, k) < 0.0) {
+                set_LTE(abundance, temperature, p, k);
+                population_inversions = true; // err, technically this isn't thread safe, but we are
+                                              // only trying to set a flag to true
+                // break;
+            }
+        }
+    });
+
+    if (population_inversions) {
+        std::cout << "Minor warning: population inversions detected; Magritte does not handle "
+                     "masers, so setting affected populations to LTE."
+                  << std::endl;
+    }
 }

--- a/src/model/lines/lines.cpp
+++ b/src/model/lines/lines.cpp
@@ -90,10 +90,11 @@ void Lines ::iteration_using_LTE(const Double2& abundance, const Vector<Real>& t
     // gather_emissivities_and_opacities ();
 }
 
-void Lines ::iteration_using_Ng_acceleration(const Real pop_prec) {
+void Lines ::iteration_using_Ng_acceleration(
+    const Double2& abundance, const Vector<Real>& temperature, const Real pop_prec) {
     for (LineProducingSpecies& lspec : lineProducingSpecies) {
         lspec.update_using_Ng_acceleration();
-        lspec.correct_negative_populations();
+        lspec.correct_negative_populations(abundance, temperature);
         lspec.check_for_convergence(pop_prec);
     }
 
@@ -102,10 +103,11 @@ void Lines ::iteration_using_Ng_acceleration(const Real pop_prec) {
     // gather_emissivities_and_opacities ();
 }
 
-void Lines ::iteration_using_Ng_acceleration(const Real pop_prec, const Size order) {
+void Lines ::iteration_using_Ng_acceleration(const Double2& abundance,
+    const Vector<Real>& temperature, const Real pop_prec, const Size order) {
     for (LineProducingSpecies& lspec : lineProducingSpecies) {
         lspec.update_using_acceleration(order);
-        lspec.correct_negative_populations();
+        lspec.correct_negative_populations(abundance, temperature);
         lspec.check_for_convergence(pop_prec);
     }
 
@@ -125,7 +127,7 @@ void Lines ::iteration_using_statistical_equilibrium(
     const Double2& abundance, const Vector<Real>& temperature, const Real pop_prec) {
     for (LineProducingSpecies& lspec : lineProducingSpecies) {
         lspec.update_using_statistical_equilibrium(abundance, temperature);
-        lspec.correct_negative_populations();
+        lspec.correct_negative_populations(abundance, temperature);
         lspec.check_for_convergence(pop_prec);
     }
 
@@ -138,7 +140,7 @@ void Lines ::iteration_using_statistical_equilibrium_sparse(
     const Double2& abundance, const Vector<Real>& temperature, const Real pop_prec) {
     for (LineProducingSpecies& lspec : lineProducingSpecies) {
         lspec.update_using_statistical_equilibrium_sparse(abundance, temperature);
-        lspec.correct_negative_populations();
+        lspec.correct_negative_populations(abundance, temperature);
         lspec.check_for_convergence(pop_prec);
     }
 

--- a/src/model/lines/lines.hpp
+++ b/src/model/lines/lines.hpp
@@ -35,9 +35,11 @@ struct Lines {
     void iteration_using_statistical_equilibrium_sparse(
         const Double2& abundance, const Vector<Real>& temperature, const Real pop_prec);
 
-    void iteration_using_Ng_acceleration(const Real pop_prec);
+    void iteration_using_Ng_acceleration(
+        const Double2& abundance, const Vector<Real>& temperature, const Real pop_prec);
 
-    void iteration_using_Ng_acceleration(const Real pop_prec, const Size order);
+    void iteration_using_Ng_acceleration(const Double2& abundance, const Vector<Real>& temperature,
+        const Real pop_prec, const Size order);
 
     void trial_iteration_using_adaptive_Ng_acceleration(const Real pop_prec, const Size order);
 

--- a/src/model/lines/lines.tpp
+++ b/src/model/lines/lines.tpp
@@ -37,6 +37,34 @@ inline void Lines ::set_emissivity_and_opacity() {
             }
         }
     })
+
+    // // check whether negative opacities are present, and set the corresponding species to LTE
+    // // And recomputes the emissivity and opacity (for those species); but TODO: i'm just
+    // recomputing
+    // // for everything
+    // for (Size p = 0; p < parameters->npoints(); p++) {
+    //     for (Size l = 0; l < parameters->nlspecs(); l++) {
+    //         for (Size k = 0; k < lineProducingSpecies[l].linedata.nrad; k++) {
+    //             const Size lid = line_index(l, k);
+
+    //             if (opacity(p, lid) < 0.0) {
+    //                 lineProducingSpecies[l].set_LTE(p);
+    //                 break;
+    //             }
+    //         }
+    //     }
+    // }
+
+    // threaded_for(p, parameters->npoints(), {
+    //     for (Size l = 0; l < parameters->nlspecs(); l++) {
+    //         for (Size k = 0; k < lineProducingSpecies[l].linedata.nrad; k++) {
+    //             const Size lid = line_index(l, k);
+
+    //             emissivity(p, lid) = lineProducingSpecies[l].get_emissivity(p, k);
+    //             opacity(p, lid)    = lineProducingSpecies[l].get_opacity(p, k);
+    //         }
+    //     }
+    // })
 }
 
 ///  Setter for line widths

--- a/src/model/lines/lines.tpp
+++ b/src/model/lines/lines.tpp
@@ -37,34 +37,6 @@ inline void Lines ::set_emissivity_and_opacity() {
             }
         }
     })
-
-    // // check whether negative opacities are present, and set the corresponding species to LTE
-    // // And recomputes the emissivity and opacity (for those species); but TODO: i'm just
-    // recomputing
-    // // for everything
-    // for (Size p = 0; p < parameters->npoints(); p++) {
-    //     for (Size l = 0; l < parameters->nlspecs(); l++) {
-    //         for (Size k = 0; k < lineProducingSpecies[l].linedata.nrad; k++) {
-    //             const Size lid = line_index(l, k);
-
-    //             if (opacity(p, lid) < 0.0) {
-    //                 lineProducingSpecies[l].set_LTE(p);
-    //                 break;
-    //             }
-    //         }
-    //     }
-    // }
-
-    // threaded_for(p, parameters->npoints(), {
-    //     for (Size l = 0; l < parameters->nlspecs(); l++) {
-    //         for (Size k = 0; k < lineProducingSpecies[l].linedata.nrad; k++) {
-    //             const Size lid = line_index(l, k);
-
-    //             emissivity(p, lid) = lineProducingSpecies[l].get_emissivity(p, k);
-    //             opacity(p, lid)    = lineProducingSpecies[l].get_opacity(p, k);
-    //         }
-    //     }
-    // })
 }
 
 ///  Setter for line widths

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -599,7 +599,8 @@ int Model ::compute_level_populations(const bool use_Ng_acceleration, const long
         if (use_ng_acceleration_step) {
             std::cout << "max order: " << iteration_normal
                       << " used order: " << ng_acceleration_order << std::endl;
-            lines.iteration_using_Ng_acceleration(parameters->pop_prec, ng_acceleration_order);
+            lines.iteration_using_Ng_acceleration(chemistry.species.abundance,
+                thermodynamics.temperature.gas, parameters->pop_prec, ng_acceleration_order);
 
             iteration_normal = 0;
         } else {
@@ -701,7 +702,8 @@ int Model ::compute_level_populations_sparse(
         if (use_ng_acceleration_step) {
             std::cout << "Ng acceleration max order: " << iteration_normal
                       << " used order: " << ng_acceleration_order << std::endl;
-            lines.iteration_using_Ng_acceleration(parameters->pop_prec, ng_acceleration_order);
+            lines.iteration_using_Ng_acceleration(chemistry.species.abundance,
+                thermodynamics.temperature.gas, parameters->pop_prec, ng_acceleration_order);
 
             iteration_normal = 0;
         } else {
@@ -803,7 +805,8 @@ int Model ::compute_level_populations_shortchar(
         if (use_ng_acceleration_step) {
             std::cout << "Ng acceleration max order: " << iteration_normal
                       << " used order: " << ng_acceleration_order << std::endl;
-            lines.iteration_using_Ng_acceleration(parameters->pop_prec, ng_acceleration_order);
+            lines.iteration_using_Ng_acceleration(chemistry.species.abundance,
+                thermodynamics.temperature.gas, parameters->pop_prec, ng_acceleration_order);
 
             iteration_normal = 0;
         } else {

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -73,12 +73,14 @@ struct Parameters {
     Real max_width_fraction = 0.35; // max diff is +-2.5%
     // Real max_width_fraction          = 0.3;//max diff is
     // +-2%
-    Real convergence_fraction        = 0.995;
-    Real min_rel_pop_for_convergence = 1.0e-10;
-    Real pop_prec                    = 1.0e-6;
-    Real min_opacity                 = 1.0e-26;
-    Real min_dtau                    = 1.0e-15;
-    bool store_intensities           = false;
+    Real convergence_fraction          = 0.995;
+    Real min_rel_pop_for_convergence   = 1.0e-10;
+    Real pop_prec                      = 1.0e-6;
+    Real min_opacity                   = 1.0e-26;
+    Real min_dtau                      = 1.0e-15;
+    Real population_inversion_fraction = 1.01; // threshold factor for population inversion required
+                                               // for LTE to be used; set this higher than 1
+    bool store_intensities = false;
     // bool use_Ng_acceleration         = true;//Not used,
     // so may safely be removed
     bool use_adaptive_Ng_acceleration = true;    // whether to use an adaptive version of Ng


### PR DESCRIPTION
Fixes the bug #245, by setting (almost) masering lines to LTE. This should solve any errors related to negative/very low line opacities.
Edit: extra clarification: This is done on a point-by-point, line-by-line basis. This change should mainly impact lower density regions, which are tricky to handle.

Note: I am still doing some manual verification whether it solves everything in non-benchmark NLTE models, but will probably merge this change soon.