### PR TITLE
Implemented other workaround for masering values

### DIFF
--- a/dependencies/conda_env.yml
+++ b/dependencies/conda_env.yml
@@ -13,7 +13,7 @@ dependencies:
   - vtk
   - jupyterlab
   - yt
-  - scipy
+  - scipy <= 1.13
   - mpi4py
   - plotly
   - pyyaml

--- a/docs/src/4_extra_options/NLTE_in_low_density.rst
+++ b/docs/src/4_extra_options/NLTE_in_low_density.rst
@@ -5,12 +5,27 @@ In low density regimes, the level populations might start to maser.
 This means that the resulting line opacity (and optical depth) can become close to zero or even negative.
 Unfortunately, our solvers cannot handle this situation too well, and might produce unphysical results.
 
-In more recent versions of the code (starting from version 0.5.3), a workaround has been implemented to avoid this situation by resetting specific levels at specific places to LTE.
+This is why we implement a workaround by setting the minimum allowed value for the line opacity (starting from version 0.7.0).
+This value is set to 1e-13 [W sr−1 m−3] by default, but can be changed by the user. Higher values might overestimate the impact of the less dense model regions on the intensity, while lower value can lead to numerical artifacts in the NLTE intensities.
+
+.. code-block:: python
+
+    parameters.min_line_opacity = 1e-13#default
+
+In versions 0.5.3 until 0.6.0, the code implemented another workaround to avoid this situation by resetting specific levels at specific places to LTE.
 This might work in some cases (with the caveat of some artifacts being produced in the resulting spectrum), 
 but might as well produce new artifacts in when doing NLTE line radiative transfer in extremely low density regions. 
 
-To restore the previous behavior (without the new workaround), one can call
+To restore that behavior (without the new workaround), one can call
+
+.. code-block:: python
+
+    parameters.population_inversion_fraction = 1.01#previous default
+    parameters.min_line_opacity = -1
+
+Finally, to restore the behavior of the code before version 0.5.3 (not recommended when using NLTE), one can call
 
 .. code-block:: python
 
     parameters.population_inversion_fraction = -1
+    parameters.min_line_opacity = -1

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -288,6 +288,8 @@ PYBIND11_MODULE(core, module) {
         .def_readwrite("pop_prec", &Parameters::pop_prec, "Required precision for ALI.")
         .def_readwrite("min_opacity", &Parameters::min_opacity,
             "Minimum opacity that will be assumed in the solver.")
+        .def_readwrite("min_line_opacity", &Parameters::min_line_opacity,
+            "Minimum line opacity that will be assumed in the solver.")
         .def_readwrite("min_dtau", &Parameters::min_dtau,
             "Minimum optical depth increment that will be assumed in the solver.")
         .def_readwrite("population_inversion_fraction", &Parameters::population_inversion_fraction,

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -73,13 +73,15 @@ struct Parameters {
     Real max_width_fraction = 0.35; // max diff is +-2.5%
     // Real max_width_fraction          = 0.3;//max diff is
     // +-2%
-    Real convergence_fraction          = 0.995;
-    Real min_rel_pop_for_convergence   = 1.0e-10;
-    Real pop_prec                      = 1.0e-6;
-    Real min_opacity                   = 1.0e-26;
-    Real min_dtau                      = 1.0e-15;
-    Real population_inversion_fraction = 1.01; // threshold factor for population inversion required
-                                               // for LTE to be used; set this higher than 1
+    Real convergence_fraction        = 0.995;
+    Real min_rel_pop_for_convergence = 1.0e-10;
+    Real pop_prec                    = 1.0e-6;
+    Real min_opacity                 = 1.0e-26;
+    long double min_line_opacity     = 1.0e-13;
+    Real min_dtau                    = 1.0e-15;
+    Real population_inversion_fraction =
+        -1.0; // previously 1.01; // threshold factor for population inversion required
+              //  for LTE to be used; set this higher than 1
     bool store_intensities = false;
     // bool use_Ng_acceleration         = true;//Not used,
     // so may safely be removed

--- a/tests/benchmarks/analytic/all_zero_single_ray.py
+++ b/tests/benchmarks/analytic/all_zero_single_ray.py
@@ -66,12 +66,12 @@ def create_model ():
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 
@@ -176,8 +176,8 @@ def run_model (nosave=False):
         plt.show()
 
     #error bounds are chosen somewhat arbitrarily, based on previously obtained results; this should prevent serious regressions.
-    FIRSTORDER_AS_EXPECTED=(np.max(error_u_0s)<2.0e-6)
-    FEAUTRIER_AS_EXPECTED=(np.max(error_u_2f)<2.0e-6)
+    FIRSTORDER_AS_EXPECTED=(np.max(error_u_0s)<6.42e-6)
+    FEAUTRIER_AS_EXPECTED=(np.max(error_u_2f)<6.41e-6)
 
     if not FIRSTORDER_AS_EXPECTED:
         print("First order solver max error too large: ", np.max(error_u_0s))

--- a/tests/benchmarks/analytic/density_distribution_1D.py
+++ b/tests/benchmarks/analytic/density_distribution_1D.py
@@ -71,12 +71,12 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 
@@ -238,8 +238,8 @@ def run_model (a_or_b, nosave=False, use_widgets=True):
     #setting 'b' not yet used for testing
     if a_or_b == 'a':
         #error bounds are chosen somewhat arbitrarily, based on previously obtained results; this should prevent serious regressions.
-        FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<3e-4)
-        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<2.7e-4)
+        FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<4.4e-4)
+        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<4.1e-4)
 
         if not FIRSTORDER_AS_EXPECTED:
             print("First order solver mean error too large: ", np.mean(error_u_0s))


### PR DESCRIPTION
Now bounds the minimum line opacity instead of resetting the level populations.
The result should be more physical, and it should be consistent across platforms (see failing CI test of #261).