### PR TITLE
260 documentation update required

### DIFF
--- a/docs/src/1_examples/0_creating_models/0_create_analytic_disk.ipynb
+++ b/docs/src/1_examples/0_creating_models/0_create_analytic_disk.ipynb
@@ -510,11 +510,11 @@
     "model.geometry.rays.direction.set(direction)          # Comment out to use all directions\n",
     "model.geometry.rays.weight   .set(0.5 * np.ones(2))   # Comment out to use all directions\n",
     "\n",
-    "# model = setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
-    "model = setup.set_boundary_condition_CMB  (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
-    "# model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
-    "model = setup.set_quadrature              (model)\n",
+    "# setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
+    "setup.set_boundary_condition_CMB  (model)\n",
+    "setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
+    "# setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
+    "setup.set_quadrature              (model)\n",
     "\n",
     "model.write()"
    ]
@@ -686,7 +686,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/src/1_examples/0_creating_models/1_create_analytic_spiral.ipynb
+++ b/docs/src/1_examples/0_creating_models/1_create_analytic_spiral.ipynb
@@ -589,11 +589,11 @@
     "model.parameters.set_nboundary(nb_boundary)\n",
     "model.geometry.boundary.boundary2point.set(np.arange(nb_boundary))\n",
     "\n",
-    "model = setup.set_boundary_condition_CMB  (model)\n",
-    "model = setup.set_uniform_rays            (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
-    "# model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
-    "model = setup.set_quadrature              (model)\n",
+    "setup.set_boundary_condition_CMB  (model)\n",
+    "setup.set_uniform_rays            (model)\n",
+    "setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
+    "# setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
+    "setup.set_quadrature              (model)\n",
     "\n",
     "model.write()"
    ]

--- a/docs/src/1_examples/1_post-processing/0_create_AMRVAC_1D.ipynb
+++ b/docs/src/1_examples/1_post-processing/0_create_AMRVAC_1D.ipynb
@@ -315,12 +315,12 @@
     "model.thermodynamics.temperature.gas  .set(tmp)\n",
     "model.thermodynamics.turbulence.vturb2.set(trb)\n",
     "\n",
-    "model = setup.set_Delaunay_neighbor_lists  (model)\n",
-    "model = setup.set_Delaunay_boundary        (model)\n",
-    "model = setup.set_boundary_condition_CMB   (model)\n",
-    "model = setup.set_uniform_rays             (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file (model, lamda_file)\n",
-    "model = setup.set_quadrature               (model)\n",
+    "setup.set_Delaunay_neighbor_lists  (model)\n",
+    "setup.set_Delaunay_boundary        (model)\n",
+    "setup.set_boundary_condition_CMB   (model)\n",
+    "setup.set_uniform_rays             (model)\n",
+    "setup.set_linedata_from_LAMDA_file (model, lamda_file)\n",
+    "setup.set_quadrature               (model)\n",
     "\n",
     "model.write()"
    ]

--- a/docs/src/1_examples/1_post-processing/1_create_AMRVAC_3D.ipynb
+++ b/docs/src/1_examples/1_post-processing/1_create_AMRVAC_3D.ipynb
@@ -364,11 +364,11 @@
     "# model.geometry.boundary.boundary2point.set(np.arange(boundary.shape[0]))\n",
     "model.geometry.boundary.boundary2point.set(boundary)\n",
     "\n",
-    "model = setup.set_boundary_condition_CMB  (model)\n",
-    "model = setup.set_uniform_rays            (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
-    "# model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
-    "model = setup.set_quadrature              (model)\n",
+    "setup.set_boundary_condition_CMB  (model)\n",
+    "setup.set_uniform_rays            (model)\n",
+    "setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
+    "# setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
+    "setup.set_quadrature              (model)\n",
     "\n",
     "model.write()"
    ]

--- a/docs/src/1_examples/1_post-processing/2_reduce_AMRVAC_3D.ipynb
+++ b/docs/src/1_examples/1_post-processing/2_reduce_AMRVAC_3D.ipynb
@@ -350,11 +350,11 @@
     "model.parameters.set_nboundary(nb_boundary)\n",
     "model.geometry.boundary.boundary2point.set(range(nb_boundary))\n",
     "\n",
-    "model = setup.set_boundary_condition_CMB  (model)\n",
-    "model = setup.set_uniform_rays            (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
-    "# model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
-    "model = setup.set_quadrature              (model)\n",
+    "setup.set_boundary_condition_CMB  (model)\n",
+    "setup.set_uniform_rays            (model)\n",
+    "setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
+    "# setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
+    "setup.set_quadrature              (model)\n",
     "\n",
     "model.write()"
    ]

--- a/docs/src/1_examples/1_post-processing/3_create_Phantom_3D.ipynb
+++ b/docs/src/1_examples/1_post-processing/3_create_Phantom_3D.ipynb
@@ -332,11 +332,11 @@
     "model.geometry.rays.direction.set(direction)          # Comment out to use all directions\n",
     "model.geometry.rays.weight   .set(0.5 * np.ones(2))   # Comment out to use all directions\n",
     "\n",
-    "# model = setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
-    "model = setup.set_boundary_condition_CMB  (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
-    "# model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
-    "model = setup.set_quadrature              (model)\n",
+    "# setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
+    "setup.set_boundary_condition_CMB  (model)\n",
+    "setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
+    "# setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
+    "setup.set_quadrature              (model)\n",
     "\n",
     "model.write()"
    ]
@@ -457,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/src/1_examples/1_post-processing/3_create_Phantom_3D_column.ipynb
+++ b/docs/src/1_examples/1_post-processing/3_create_Phantom_3D_column.ipynb
@@ -345,10 +345,10 @@
     "model.parameters.set_nboundary(boundary.shape[0])\n",
     "model.geometry.boundary.boundary2point.set(boundary)\n",
     "\n",
-    "model = setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
-    "model = setup.set_boundary_condition_CMB  (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
-    "model = setup.set_quadrature              (model)\n",
+    "setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
+    "setup.set_boundary_condition_CMB  (model)\n",
+    "setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
+    "setup.set_quadrature              (model)\n",
     "\n",
     "model.write()"
    ]

--- a/docs/src/1_examples/1_post-processing/4_reduce_Phantom_3D.ipynb
+++ b/docs/src/1_examples/1_post-processing/4_reduce_Phantom_3D.ipynb
@@ -378,11 +378,11 @@
     "model.geometry.rays.direction.set(direction)          # Comment out to use all directions\n",
     "model.geometry.rays.weight   .set(0.5 * np.ones(2))   # Comment out to use all directions\n",
     "\n",
-    "# model = setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
-    "model = setup.set_boundary_condition_CMB  (model)\n",
-    "model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
-    "# model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
-    "model = setup.set_quadrature              (model)\n",
+    "# setup.set_uniform_rays            (model)   # Uncomment to use all directions\n",
+    "setup.set_boundary_condition_CMB  (model)\n",
+    "setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})\n",
+    "# setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions\n",
+    "setup.set_quadrature              (model)\n",
     "\n",
     "model.write()"
    ]
@@ -498,7 +498,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.16"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/src/4_extra_options/NLTE_in_low_density.rst
+++ b/docs/src/4_extra_options/NLTE_in_low_density.rst
@@ -6,7 +6,7 @@ This means that the resulting line opacity (and optical depth) can become close 
 Unfortunately, our solvers cannot handle a rapid change in source function (emissivity/opacity) too well, and might produce unphysical results.
 
 This is why we implement a workaround by setting the minimum allowed value for the line opacity (starting from version 0.7.0).
-This value is set to 1e-10 [W sr−1 m−3] by default, but can be changed by the user. Higher values might overestimate the impact of the less dense model regions on the intensity, while lower value can lead to numerical artifacts in the NLTE intensities.
+This value is set to 1e-10 [W sr−1 m−3] by default, but can be changed by the user. Higher values can overestimate the impact of the less dense model regions on the intensity, while lower value can lead to numerical artifacts in the NLTE intensities (ring-like structures in the channel maps).
 
 .. code-block:: python
 

--- a/tests/benchmarks/analytic/all_constant_single_ray.py
+++ b/tests/benchmarks/analytic/all_constant_single_ray.py
@@ -57,12 +57,12 @@ def create_model ():
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/all_constant_single_ray_testuv.py
+++ b/tests/benchmarks/analytic/all_constant_single_ray_testuv.py
@@ -59,12 +59,12 @@ def create_model ():
     model.thermodynamics.temperature.gas  .set( temp * (1.0+10*np.arange(npoints)/npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/constant_velocity_gradient_1D.py
+++ b/tests/benchmarks/analytic/constant_velocity_gradient_1D.py
@@ -61,12 +61,12 @@ def create_model ():
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/constant_velocity_gradient_1D_image.py
+++ b/tests/benchmarks/analytic/constant_velocity_gradient_1D_image.py
@@ -61,12 +61,12 @@ def create_model ():
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/constant_velocity_gradient_1D_new_imager.py
+++ b/tests/benchmarks/analytic/constant_velocity_gradient_1D_new_imager.py
@@ -61,12 +61,12 @@ def create_model ():
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/constant_velocity_gradient_3D_new_imager.py
+++ b/tests/benchmarks/analytic/constant_velocity_gradient_3D_new_imager.py
@@ -93,10 +93,10 @@ def create_model ():
     model.geometry.boundary.boundary2point.set(boundary2point)
     model.parameters.set_nboundary(len(boundary2point))
 
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/density_distribution_1D_image.py
+++ b/tests/benchmarks/analytic/density_distribution_1D_image.py
@@ -71,12 +71,12 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/density_distribution_single_ray.py
+++ b/tests/benchmarks/analytic/density_distribution_single_ray.py
@@ -70,12 +70,12 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/analytic/reject_nonexistent_species.py
+++ b/tests/benchmarks/analytic/reject_nonexistent_species.py
@@ -55,13 +55,13 @@ def create_model ():
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
     #The next line should throw an error, as we expect the list of chemical species to contain the name of the species we are reading in ('test').
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/import_phantom_3D_model.py
+++ b/tests/benchmarks/numeric/import_phantom_3D_model.py
@@ -131,11 +131,11 @@ def import_phantom():
     # model.geometry.rays.direction.set(direction)          # Comment out to use all directions
     # model.geometry.rays.weight   .set(0.5 * np.ones(2))   # Comment out to use all directions
 
-    model = setup.set_uniform_rays            (model)   # Uncomment to use all directions
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})
+    setup.set_uniform_rays            (model)   # Uncomment to use all directions
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})
     # model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions
-    model = setup.set_quadrature              (model)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/read_shuffled_lines_one_line_approx.py
+++ b/tests/benchmarks/numeric/read_shuffled_lines_one_line_approx.py
@@ -73,13 +73,13 @@ def create_model():
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
     #boundary intensity should be approx 0 for the frequencies we care about
-    model = setup.set_boundary_condition_1D   (model, T_bound, T_bound)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_boundary_condition_1D   (model, T_bound, T_bound)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/reduce_phantom_3D_model.py
+++ b/tests/benchmarks/numeric/reduce_phantom_3D_model.py
@@ -103,11 +103,11 @@ def reduce_phantom():
     # model.geometry.rays.direction.set(direction)          # Comment out to use all directions
     # model.geometry.rays.weight   .set(0.5 * np.ones(2))   # Comment out to use all directions
 
-    model = setup.set_uniform_rays            (model)   # Uncomment to use all directions
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})
+    setup.set_uniform_rays            (model)   # Uncomment to use all directions
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})
     # model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions
-    model = setup.set_quadrature              (model)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_1_1D.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_1_1D.py
@@ -73,12 +73,12 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_1_1D_sparse.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_1_1D_sparse.py
@@ -73,12 +73,12 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_1_3D_healpix.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_1_3D_healpix.py
@@ -86,7 +86,7 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_neighbor_lists (model)
 
     boundary2point  = [b for b in range(npoints_in_shell[0])]
     boundary2point += [b for b in range(npoints-npoints_in_shell[-1], npoints)]
@@ -94,10 +94,10 @@ def create_model (a_or_b):
     model.geometry.boundary.boundary2point.set(boundary2point)
     model.parameters.set_nboundary(len(boundary2point))
 
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_1_3D_mesher.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_1_3D_mesher.py
@@ -99,15 +99,15 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set( temp                 * np.ones(npoints))
     model.thermodynamics.turbulence.vturb2.set((turb/magritte.CC)**2 * np.ones(npoints))
 
-    model = setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_neighbor_lists (model)
 
     model.parameters.set_nboundary(len(mesh.boundary))
     model.geometry.boundary.boundary2point.set(mesh.boundary)
 
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_2_1D.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_2_1D.py
@@ -69,12 +69,12 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set(temp   )
     model.thermodynamics.turbulence.vturb2.set(turb**2)
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_2_1D_one_line_approx.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_2_1D_one_line_approx.py
@@ -71,12 +71,12 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set(temp   )
     model.thermodynamics.turbulence.vturb2.set(turb**2)
 
-    model = setup.set_Delaunay_neighbor_lists (model)
-    model = setup.set_Delaunay_boundary       (model)
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_rays_spherical_symmetry (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_boundary       (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_rays_spherical_symmetry (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_2_3D_healpix.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_2_3D_healpix.py
@@ -93,7 +93,7 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set([temp_int(r)    for r in rs])
     model.thermodynamics.turbulence.vturb2.set([turb_int(r)**2 for r in rs])
 
-    model = setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_neighbor_lists (model)
 
     boundary2point  = [b for b in range(npoints_in_shell[0])]
     boundary2point += [b for b in range(npoints-npoints_in_shell[-1], npoints)]
@@ -101,10 +101,10 @@ def create_model (a_or_b):
     model.parameters.set_nboundary(len(boundary2point))
     model.geometry.boundary.boundary2point.set(boundary2point)
 
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 

--- a/tests/benchmarks/numeric/vanZadelhoff_2_3D_mesher.py
+++ b/tests/benchmarks/numeric/vanZadelhoff_2_3D_mesher.py
@@ -112,15 +112,15 @@ def create_model (a_or_b):
     model.thermodynamics.temperature.gas  .set([temp_int(r)    for r in rs])
     model.thermodynamics.turbulence.vturb2.set([turb_int(r)**2 for r in rs])
 
-    model = setup.set_Delaunay_neighbor_lists (model)
+    setup.set_Delaunay_neighbor_lists (model)
 
     model.parameters.set_nboundary(len(mesh.boundary))
     model.geometry.boundary.boundary2point.set(mesh.boundary)
 
-    model = setup.set_boundary_condition_CMB  (model)
-    model = setup.set_uniform_rays            (model)
-    model = setup.set_linedata_from_LAMDA_file(model, lamdaFile)
-    model = setup.set_quadrature              (model)
+    setup.set_boundary_condition_CMB  (model)
+    setup.set_uniform_rays            (model)
+    setup.set_linedata_from_LAMDA_file(model, lamdaFile)
+    setup.set_quadrature              (model)
 
     model.write()
 


### PR DESCRIPTION
Removed the `'model = '` from the typical `model = setup. ...(model)` part in the model creation, as this did not do anything.
The model gets modified anyway in all the setup scripts.