### PR TITLE
Adaptive ray directions

### DIFF
--- a/.github/workflows/build-and-test-on-pr.yml
+++ b/.github/workflows/build-and-test-on-pr.yml
@@ -46,8 +46,8 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            C-COMPILER: gcc-11
-            CXX-COMPILER: g++-11
+            C-COMPILER: gcc-14
+            CXX-COMPILER: g++-14
           - os: ubuntu-latest
             C-COMPILER: gcc
             CXX-COMPILER: g++

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,8 +67,8 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            C-COMPILER: gcc-11
-            CXX-COMPILER: g++-11
+            C-COMPILER: gcc-14
+            CXX-COMPILER: g++-14
           - os: ubuntu-latest
             C-COMPILER: gcc
             CXX-COMPILER: g++

--- a/magritte/adaptive_ray_directions.py
+++ b/magritte/adaptive_ray_directions.py
@@ -1,0 +1,189 @@
+import healpy as hp
+import numpy as np
+import concurrent.futures
+
+class AdaptiveRayDirectionHelper:
+    def __init__(self, positions: np.ndarray, Ntop: int = 2, Nrefinements: int = 4, Ncomparisons: int = 4000) -> None:
+        """Initializes the AdaptiveRayDirections class
+
+        Args:
+            positions (np.ndarray): 3D positions of the points (used for guessing the most important directions)
+            Ntop (int, optional): Refinement parameter. Determines how much can be refined in each level. Should correspond to at least the number of interesting regions in the model. Defaults to 2.
+            Nrefinements (int, optional): Refinement parameter. Determines the amount of refinement levels. Defaults to 4.
+            Ncomparisons (int, optional): Randomly sample Ncomparison positions for determine the adaptive ray directions. Required computation time scales linearly. Defaults to 4000.
+        """
+        self.Nrefinements: int = Nrefinements
+        self.Nside: int = 2**Nrefinements
+        self.Npix: int = 12*self.Nside**2
+        self.halfNpix: int = self.Npix//2
+        self.Ntop: int = Ntop
+        self.Ncomparisons: int = Ncomparisons
+        self.N_adaptive_angles: int = self.get_number_adaptive_directions()
+        self.half_N_adaptive_angles: int = self.N_adaptive_angles//2
+        self.positions: np.ndarray[None, 3] = positions
+        if Ncomparisons>=positions.shape[0]:
+            self.refpositions = positions
+        else:
+            self.refpositions = self.positions[np.random.choice(self.positions.shape[0], self.Ncomparisons)]
+
+    def get_number_adaptive_directions(self) -> int:
+        """Returns the number of adaptive ray directions
+
+        Returns:
+            int: Number of adaptive ray directions
+        """
+        sum_angles: int = 12
+        for i in range(self.Nrefinements):
+            sum_angles += 6*min(self.Ntop, 6*4**(i))
+
+        return sum_angles
+    
+    def calc_pixcount(self, posidx: int) -> np.ndarray:
+        """Calculates the number of reference points in each pixel
+
+        Args:
+            posidx (int): Position index
+
+        Returns:
+            np.ndarray[self.Npix]: Number of counts per pixel
+        """
+        diffpos = self.refpositions - self.positions[posidx, :]
+        pix = hp.vec2pix(self.Nside, diffpos[:,0], diffpos[:,1], diffpos[:,2])
+        pixcount = np.bincount(pix, minlength = self.Npix)
+
+        return pixcount
+    
+    def get_adaptive_direction_weight(self, pixcount):
+        #upper bounds for array size; will need to be pruned later TODO: get exact size precomputed; all positions must have same size, due to the number of available directions being the same
+        #Magritte uses symmetric ray directions; so I just added the oppisite bins at the start
+        #To get the antipodal directions, just grab first half of healpix indices; then let healpix compute the corresponding -dir indices
+        best_weights = np.zeros(self.N_adaptive_angles)
+        best_directions = np.zeros((self.N_adaptive_angles, 3))
+        
+        #use nested ordering, for easier referinement operations
+        full_nested_pixel_ordering = hp.reorder(pixcount, r2n=True)
+        # Magritte uses antipodal rays, so compute them; unfortunately healpy api returns tuples for some reason... (-> vstack)
+        antipodal_indices_nest = hp.vec2pix(self.Nside, *-np.vstack(hp.pix2vec(self.Nside, np.arange(self.halfNpix), nest=True)), nest=True)
+        #algorithm mainly intended for improving ray discretization on outside of model, so use the maximum instead of the mean.
+        nested_pixel_ordering = np.maximum(full_nested_pixel_ordering[:self.halfNpix], full_nested_pixel_ordering[antipodal_indices_nest])
+
+
+        #TODO: think about which kind of average to use for the coarser level
+        coarser_values = nested_pixel_ordering[::4] + nested_pixel_ordering[1::4] + nested_pixel_ordering[2::4] + nested_pixel_ordering[3::4]
+        levels_to_pick = min(self.Ntop, self.halfNpix//4)#on the coarser grid (half the rays, 1/4 for coarsening)
+        highest_coarser_indices = np.argpartition(coarser_values, -levels_to_pick)[-levels_to_pick:]
+        already_picked_indices = 0
+        
+        if levels_to_pick>0:
+            best_directions[:4*levels_to_pick, :] = np.vstack(hp.pix2vec(self.Nside, 4*np.repeat(highest_coarser_indices, 4)+np.tile(np.arange(4), levels_to_pick), nest=True)).T
+        
+            # All directions at a given level have equal weight
+            best_weights[:4*levels_to_pick] = 1.0/self.Npix#*np.ones(4*levels_to_pick)
+
+        already_picked_indices += 4*levels_to_pick
+
+        #Limit the amount of iterations, as hp.pix2vec doesnt handle empty arrays.
+        max_iter = self.Nrefinements - 1 - max(0, int(np.floor(np.log2(self.Ntop/6)/2)))
+
+        for i in range(max_iter):
+            # For consistency, the discretizations at a finer level must also have some corresponding discretization at a higher level
+            already_planned_indices = np.unique(highest_coarser_indices//4)
+            len_plan_indices = len(already_planned_indices)
+            # Amount of discretizations to pick is limited by the number of already planned indices
+            levels_to_pick = max(0, min(self.Ntop, self.halfNpix//(4**(i+2)))-len_plan_indices)
+            proposed_indices = 4*np.repeat(already_planned_indices, 4)+np.tile(np.arange(4), len(already_planned_indices))
+            proposed_indices = np.array(list(set(proposed_indices) - set(highest_coarser_indices)))#is on the current level
+            len_prop_indices = len(proposed_indices)
+            
+            # Add the already planned directions (if nonzero amount)
+            if len_prop_indices>0:
+                best_directions[already_picked_indices:already_picked_indices+len_prop_indices, :] = np.vstack(hp.pix2vec(2**(self.Nrefinements-i-1), proposed_indices, nest=True)).T
+                best_weights[already_picked_indices:already_picked_indices+len_prop_indices] = 4**(i+1)/self.Npix#*np.ones(len_prop_indices)
+            
+            already_picked_indices += len_prop_indices
+            
+            # And calculate statistics for the coarser level, in order to pick an additional levels_to_pick discretized directions
+            coarser_values = coarser_values[::4] + coarser_values[1::4] + coarser_values[2::4] + coarser_values[3::4]
+            # But make sure we never pick the indices we have already taken
+            coarser_values[already_planned_indices] = -1
+            # Hack: either use n (nonzero) last elements, or if zero, explicitly say no elements
+            highest_coarser_indices = np.argpartition(coarser_values, -levels_to_pick)[-levels_to_pick or len(coarser_values):]
+            
+            # And now add these chosen directions
+            best_directions[already_picked_indices:already_picked_indices+4*levels_to_pick, :] = np.vstack(hp.pix2vec(2**(self.Nrefinements-i-1), 4*np.repeat(highest_coarser_indices, 4)+np.tile(np.arange(4), levels_to_pick), nest=True)).T
+            
+            best_weights[already_picked_indices:already_picked_indices+4*levels_to_pick] = 4**(i+1)/self.Npix#*np.ones(4*levels_to_pick)
+            already_picked_indices += 4*levels_to_pick
+            
+            #and add these two coarser level things together, to keep track of everything
+            highest_coarser_indices = np.concatenate((highest_coarser_indices, already_planned_indices))
+            
+        remaining_indices = np.array(list(set(np.arange(6)) - set(highest_coarser_indices)))
+        len_remaining = len(remaining_indices)
+        
+        # If clause gets triggered when topN < 6 (as then not all coarsest levels are already refined)
+        if (len(remaining_indices)>0):
+            best_directions[already_picked_indices:already_picked_indices+len_remaining, :] = np.vstack(hp.pix2vec(1, remaining_indices, nest=True)).T
+            best_weights[already_picked_indices:already_picked_indices+len_remaining] = 1.0/12.0
+        
+        
+        #Compute the antipodal directions, using the same weight
+        best_directions[self.half_N_adaptive_angles:2*self.half_N_adaptive_angles, :] = - best_directions[:self.half_N_adaptive_angles]
+        best_weights[self.half_N_adaptive_angles:2*self.half_N_adaptive_angles] = best_weights[:self.half_N_adaptive_angles]
+        #print("final weight", best_weights, np.sum(best_weights), np.sum(best_weights>0.0))
+        #print("final directions", best_directions)
+        
+        return best_directions, best_weights
+    
+
+    def get_adaptive_directions_block(self, start: int, end: int) -> 'tuple[np.ndarray, np.ndarray]':
+        """Computes the adaptive ray directions and corresponding weights for a block of positions on a single thread
+
+        Args:
+            start (int): Start index of the block
+            end (int): End index of the block
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]: Tuple containing the adaptive ray directions and corresponding weights
+        """
+        best_directions = np.zeros((end-start, self.N_adaptive_angles, 3))
+        best_weights = np.zeros((end-start, self.N_adaptive_angles))
+
+        for i in range(start, end):
+            if i%1000 == 0:
+                print(i)
+            pixcount = self.calc_pixcount(i)
+            best_directions[i-start, :, :], best_weights[i-start, :] = self.get_adaptive_direction_weight(pixcount)
+
+        return best_directions, best_weights
+    
+
+    def get_adaptive_directions(self, points_per_thread = 1000) -> 'tuple[np.ndarray, np.ndarray]':
+        """Computes the adaptive ray directions and corresponding weights
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]: Tuple containing the adaptive ray directions and corresponding weights
+        """
+        best_directions = np.zeros((self.positions.shape[0], self.N_adaptive_angles, 3))
+        best_weights = np.zeros((self.positions.shape[0], self.N_adaptive_angles))
+
+        # For each points_per_thread points, calculate the adaptive ray directions and weights
+        index_starts = np.arange(0, self.positions.shape[0], points_per_thread)
+        index_ends = np.append(index_starts[1:], self.positions.shape[0])
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            adaptive_directions_weights = executor.map(self.get_adaptive_directions_block, index_starts, index_ends)
+            for i, (directions, weights) in enumerate(adaptive_directions_weights):
+                best_directions[index_starts[i]:index_ends[i], :, :] = directions
+                best_weights[index_starts[i]:index_ends[i], :] = weights
+
+        return best_directions, best_weights
+    
+    def get_antipod_indices(self) -> np.ndarray:
+        """Returns the antipod indices, which are the same for each position
+
+        Returns:
+            np.ndarray: antipod indices; shape: (self.N_adaptive_angles,)
+        """
+        ind = np.arange(self.half_N_adaptive_angles)
+        return np.concatenate((ind + self.half_N_adaptive_angles, ind))

--- a/magritte/adaptive_ray_directions.py
+++ b/magritte/adaptive_ray_directions.py
@@ -171,6 +171,8 @@ class AdaptiveRayDirectionHelper:
         index_starts = np.arange(0, self.positions.shape[0], points_per_thread)
         index_ends = np.append(index_starts[1:], self.positions.shape[0])
 
+        print("Computing adaptive rays for points:")
+
         with concurrent.futures.ThreadPoolExecutor() as executor:
             adaptive_directions_weights = executor.map(self.get_adaptive_directions_block, index_starts, index_ends)
             for i, (directions, weights) in enumerate(adaptive_directions_weights):

--- a/magritte/setup.py
+++ b/magritte/setup.py
@@ -3,6 +3,7 @@ import scipy as sp
 import healpy
 import re
 import astroquery.lamda as lamda
+import adaptive_ray_directions as ard
 
 from magritte.core import LineProducingSpecies, vLineProducingSpecies,            \
                           CollisionPartner, vCollisionPartner, CC, HH, KB, T_CMB, \
@@ -217,6 +218,7 @@ def set_uniform_rays(model, randomize=False, first_ray=np.array([1.0, 0.0, 0.0])
     # Cast to numpy arrays of appropriate type and shape
     model.geometry.rays.direction.set(direction)
     model.geometry.rays.weight   .set((1.0/nrays) * np.ones(nrays))
+    model.geometry.rays.use_adaptive_directions = False
     # Done
     return model
 
@@ -320,6 +322,7 @@ def set_rays_spherical_symmetry(model, uniform=True, nextra=0, step=1):
     # Set the direction and the weights in the Magritte model
     model.geometry.rays.direction.set(direction)
     model.geometry.rays.weight   .set(weight)
+    model.geometry.rays.use_adaptive_directions = False
     
     # Set nrays in the model
     try:
@@ -332,6 +335,44 @@ def set_rays_spherical_symmetry(model, uniform=True, nextra=0, step=1):
             f"set nrays, or specify the right number, which is {nrays} in this particular case."
         )    
     
+    # Done
+    return model
+
+def set_adaptive_rays(model, Ntop: int = 2, Nrefiments: int = 4, Ncomparisons: int = 4000):
+    """
+    Setter for rays to uniformly distributed directions.
+
+    Parameters
+    ----------
+    model : Magritte model object
+        Magritte model object to set.
+    Ntop (int, optional): Refinement parameter. Determines how much can be refined in each level. Should correspond to at least the number of interesting regions in the model. Defaults to 2.
+    Nrefinements (int, optional): Refinement parameter. Determines the amount of refinement levels. Defaults to 4.
+    Ncomparisons (int, optional): Randomly sample Ncomparison positions for determine the adaptive ray directions. Required computation time scales linearly. Defaults to 4000.
+
+    TODO: ADD ALL OPTIONAL PARAMETERS
+
+    Returns
+    -------
+    out : Magritte model object
+        Updated Magritte object.
+    """
+    if (model.parameters.dimension() != 3):
+        raise ValueError ('Only dimension = 3 is supported.')
+    
+    ardhelper = ard.AdaptiveRayDirectionHelper(np.array(model.geometry.points.position), Ntop, Nrefiments, Ncomparisons)
+    nadaptivedir: int = ardhelper.get_number_adaptive_directions()
+    npoints: int = model.parameters.npoints()
+    adaptive_directions, adaptive_weights = ardhelper.get_adaptive_directions()
+    antipod = ardhelper.get_antipod_indices()
+
+    # Set the direction and the weights in the Magritte model
+    model.geometry.rays.direction.set(np.reshape(adaptive_directions, (npoints * nadaptivedir, 3)))
+    model.geometry.rays.weight.set(np.reshape(adaptive_weights, (npoints*nadaptivedir, 3)))
+    model.geometry.rays.antipod.set(antipod)
+    model.geometry.rays.use_adaptive_directions = True
+    model.parameters.set_nrays(nadaptivedir)
+
     # Done
     return model
 

--- a/magritte/setup.py
+++ b/magritte/setup.py
@@ -3,7 +3,7 @@ import scipy as sp
 import healpy
 import re
 import astroquery.lamda as lamda
-import adaptive_ray_directions as ard
+import magritte.adaptive_ray_directions as ard
 
 from magritte.core import LineProducingSpecies, vLineProducingSpecies,            \
                           CollisionPartner, vCollisionPartner, CC, HH, KB, T_CMB, \
@@ -368,7 +368,7 @@ def set_adaptive_rays(model, Ntop: int = 2, Nrefiments: int = 4, Ncomparisons: i
 
     # Set the direction and the weights in the Magritte model
     model.geometry.rays.direction.set(np.reshape(adaptive_directions, (npoints * nadaptivedir, 3)))
-    model.geometry.rays.weight.set(np.reshape(adaptive_weights, (npoints*nadaptivedir, 3)))
+    model.geometry.rays.weight.set(np.reshape(adaptive_weights, (npoints*nadaptivedir)))
     model.geometry.rays.antipod.set(antipod)
     model.geometry.rays.use_adaptive_directions = True
     model.parameters.set_nrays(nadaptivedir)

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -408,16 +408,24 @@ PYBIND11_MODULE(core, module) {
         .def_readwrite("use_adaptive_directions", &Rays::use_adaptive_directions,
             "Whether to use a different set of directions for each ray.")
         .def("get_direction_index", &Rays::get_direction_index<false>,
-            "Get the linearized direction index for a given point and ray, when not using an adaptive ray discretization.")
+            "Get the linearized direction index for a given point and ray, when not using an "
+            "adaptive ray discretization.")
         .def("get_direction_index_adaptive", &Rays::get_direction_index<true>,
-            "Get the linearized direction index for a given point and ray, when using the adaptive ray discretization.")
-        .def("get_direction", &Rays::get_direction<false>, "Get the direction of a ray, when not using an adaptive ray discretization.")
-        .def("get_direction_adaptive", &Rays::get_direction<true>, "Get the direction of a ray, when using the adaptive ray discretization.")
-        .def("get_antipod", &Rays::get_antipod<false>, "Get the antipodal direction of a ray, when not using an adaptive ray discretization.")
-        .def("get_antipod_adaptive", &Rays::get_antipod<true>, "Get the antipodal direction of a ray, when using the adaptive ray discretization.")
+            "Get the linearized direction index for a given point and ray, when using the adaptive "
+            "ray discretization.")
+        .def("get_direction", &Rays::get_direction<false>,
+            "Get the direction of a ray, when not using an adaptive ray discretization.")
+        .def("get_direction_adaptive", &Rays::get_direction<true>,
+            "Get the direction of a ray, when using the adaptive ray discretization.")
+        .def("get_antipod", &Rays::get_antipod<false>,
+            "Get the antipodal direction of a ray, when not using an adaptive ray discretization.")
+        .def("get_antipod_adaptive", &Rays::get_antipod<true>,
+            "Get the antipodal direction of a ray, when using the adaptive ray discretization.")
         .def("get_antipod_index", &Rays::get_antipod_index, "Get the index of the antipodal ray.")
-        .def("get_weight", &Rays::get_weight<false>, "Get the weight of a ray, when not using an adaptive ray discretization.")
-        .def("get_weight_adaptive", &Rays::get_weight<true>, "Get the weight of a ray, when using the adaptive ray discretization.")
+        .def("get_weight", &Rays::get_weight<false>,
+            "Get the weight of a ray, when not using an adaptive ray discretization.")
+        .def("get_weight_adaptive", &Rays::get_weight<true>,
+            "Get the weight of a ray, when using the adaptive ray discretization.")
         // io
         .def("read", &Rays::read, "Read object from file.")
         .def("write", &Rays::write, "Write object to file.");

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -405,6 +405,14 @@ PYBIND11_MODULE(core, module) {
         .def_readwrite("weight", &Rays::weight,
             "Array with the weights that each ray contributes in "
             "integrals over directions.")
+        .def_readwrite("use_adaptive_directions", &Rays::use_adaptive_directions,
+            "Whether to use a different set of directions for each ray.")
+        .def("get_direction_index", &Rays::get_direction_index,
+            "Get the linearized direction index for a given point and ray.")
+        .def("get_direction", &Rays::get_direction, "Get the direction of a ray.")
+        .def("get_antipod", &Rays::get_antipod, "Get the antipodal direction of a ray.")
+        .def("get_antipod_index", &Rays::get_antipod_index, "Get the index of the antipodal ray.")
+        .def("get_weight", &Rays::get_weight, "Get the weight of a ray.")
         // io
         .def("read", &Rays::read, "Read object from file.")
         .def("write", &Rays::write, "Write object to file.");

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -407,12 +407,17 @@ PYBIND11_MODULE(core, module) {
             "integrals over directions.")
         .def_readwrite("use_adaptive_directions", &Rays::use_adaptive_directions,
             "Whether to use a different set of directions for each ray.")
-        .def("get_direction_index", &Rays::get_direction_index,
-            "Get the linearized direction index for a given point and ray.")
-        .def("get_direction", &Rays::get_direction, "Get the direction of a ray.")
-        .def("get_antipod", &Rays::get_antipod, "Get the antipodal direction of a ray.")
+        .def("get_direction_index", &Rays::get_direction_index<false>,
+            "Get the linearized direction index for a given point and ray, when not using an adaptive ray discretization.")
+        .def("get_direction_index_adaptive", &Rays::get_direction_index<true>,
+            "Get the linearized direction index for a given point and ray, when using the adaptive ray discretization.")
+        .def("get_direction", &Rays::get_direction<false>, "Get the direction of a ray, when not using an adaptive ray discretization.")
+        .def("get_direction_adaptive", &Rays::get_direction<true>, "Get the direction of a ray, when using the adaptive ray discretization.")
+        .def("get_antipod", &Rays::get_antipod<false>, "Get the antipodal direction of a ray, when not using an adaptive ray discretization.")
+        .def("get_antipod_adaptive", &Rays::get_antipod<true>, "Get the antipodal direction of a ray, when using the adaptive ray discretization.")
         .def("get_antipod_index", &Rays::get_antipod_index, "Get the index of the antipodal ray.")
-        .def("get_weight", &Rays::get_weight, "Get the weight of a ray.")
+        .def("get_weight", &Rays::get_weight<false>, "Get the weight of a ray, when not using an adaptive ray discretization.")
+        .def("get_weight_adaptive", &Rays::get_weight<true>, "Get the weight of a ray, when using the adaptive ray discretization.")
         // io
         .def("read", &Rays::read, "Read object from file.")
         .def("write", &Rays::write, "Write object to file.");

--- a/src/model/geometry/geometry.hpp
+++ b/src/model/geometry/geometry.hpp
@@ -39,9 +39,11 @@ struct Geometry {
     void read(const Io& io);
     void write(const Io& io) const;
 
+    template <bool use_adaptive_directions>
     accel inline void get_next(const Size o, const Size r, const Size crt, Size& nxt, double& Z,
         double& dZ, double& shift) const;
 
+    template <bool use_adaptive_directions>
     accel inline Size get_next(
         const Size o, const Size r, const Size crt, double& Z, double& dZ) const;
 
@@ -65,7 +67,7 @@ struct Geometry {
 
     accel inline Size get_closest_bdy_point_in_custom_raydir(const Vector3D& raydir) const;
 
-    template <Frame frame>
+    template <Frame frame, bool use_adaptive_directions>
     accel inline double get_shift(const Size o, const Size r, const Size crt, const double Z) const;
 
     template <Frame frame>
@@ -84,7 +86,7 @@ struct Geometry {
     accel inline Size get_n_interpl(
         const double shift_crt, const double shift_nxt, const double dshift_max) const;
 
-    template <Frame frame>
+    template <Frame frame, bool use_adaptive_directions>
     accel inline Size get_ray_length(const Size o, const Size r, const double dshift_max) const;
 
     inline bool valid_point(const Size p) const;

--- a/src/model/geometry/geometry.tpp
+++ b/src/model/geometry/geometry.tpp
@@ -317,7 +317,7 @@ accel inline Size Geometry ::get_next(
 accel inline Size Geometry ::get_next(
     const Size o, const Size r, const Size crt, double& Z, double& dZ) const {
     const Vector3D origin = points.position[o];
-    const Vector3D raydir = rays.direction[r];
+    const Vector3D raydir = rays.get_direction(o, r);
 
     return get_next<Defaulttracer>(origin, raydir, crt, Z, dZ);
 }
@@ -472,7 +472,7 @@ inline double Geometry ::get_shift_spherical_symmetry<Rest>(const Vector3D& orig
 ///////////////////////////////////////////////////////////////////////////////////////
 template <Frame frame>
 inline double Geometry ::get_shift(const Size o, const Size r, const Size c, const double Z) const {
-    Vector3D raydir                = rays.direction[r];
+    Vector3D raydir                = rays.get_direction(o, r);
     const Vector3D origin          = points.position[o];
     const Vector3D origin_velocity = points.velocity[o];
     // Due to the old imager implementation, the computed shift might need to be

--- a/src/model/geometry/geometry.tpp
+++ b/src/model/geometry/geometry.tpp
@@ -231,19 +231,19 @@ accel inline Size Geometry ::get_n_interpl(
     }
 }
 
-template <Frame frame>
+template <Frame frame, bool use_adaptive_directions>
 accel inline Size Geometry ::get_ray_length(
     const Size o, const Size r, const double dshift_max) const {
     Size l    = 0;   // ray length
     double Z  = 0.0; // distance from origin (o)
     double dZ = 0.0; // last increment in Z
 
-    Size nxt = get_next(o, r, o, Z, dZ);
+    Size nxt = get_next<use_adaptive_directions>(o, r, o, Z, dZ);
 
     if (valid_point(nxt)) {
         Size crt         = o;
-        double shift_crt = get_shift<frame>(o, r, crt, 0.0);
-        double shift_nxt = get_shift<frame>(o, r, nxt, Z);
+        double shift_crt = get_shift<frame, use_adaptive_directions>(o, r, crt, 0.0);
+        double shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
 
         l += 1; // no interpolation means only a single point added to the ray each
                 // time
@@ -252,8 +252,8 @@ accel inline Size Geometry ::get_ray_length(
             crt       = nxt;
             shift_crt = shift_nxt;
 
-            nxt       = get_next(o, r, nxt, Z, dZ);
-            shift_nxt = get_shift<frame>(o, r, nxt, Z);
+            nxt       = get_next<use_adaptive_directions>(o, r, nxt, Z, dZ);
+            shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
 
             l += 1; // no interpolation means only a single point added to the ray
                     // each time
@@ -314,10 +314,11 @@ accel inline Size Geometry ::get_next(
 ///    @param[out]    dZ : reference to the distance increment to the next ray
 ///    @return number of the next cell on the ray after the current cell
 ///////////////////////////////////////////////////////////////////////////////////
+template <bool use_adaptive_directions>
 accel inline Size Geometry ::get_next(
     const Size o, const Size r, const Size crt, double& Z, double& dZ) const {
     const Vector3D origin = points.position[o];
-    const Vector3D raydir = rays.get_direction(o, r);
+    const Vector3D raydir = rays.get_direction<use_adaptive_directions>(o, r);
 
     return get_next<Defaulttracer>(origin, raydir, crt, Z, dZ);
 }
@@ -331,10 +332,11 @@ accel inline Size Geometry ::get_next(
 ///    @param[out]    dZ : reference to the distance increment to the next ray
 ///    @return number of the next cell on the ray after the current cell
 ///////////////////////////////////////////////////////////////////////////////////
+template <bool use_adaptive_directions>
 accel inline void Geometry ::get_next(const Size o, const Size r, const Size crt, Size& nxt,
     double& Z, double& dZ, double& shift) const {
-    nxt   = get_next(o, r, crt, Z, dZ);
-    shift = get_shift<CoMoving>(o, r, nxt, Z);
+    nxt   = get_next<use_adaptive_directions>(o, r, crt, Z, dZ);
+    shift = get_shift<CoMoving, use_adaptive_directions>(o, r, nxt, Z);
 }
 
 ///  Getter for the number of the next closer boundary point on the ray and its
@@ -470,9 +472,9 @@ inline double Geometry ::get_shift_spherical_symmetry<Rest>(const Vector3D& orig
 ///    @return doppler shift along the ray between the current cell and the
 ///    origin
 ///////////////////////////////////////////////////////////////////////////////////////
-template <Frame frame>
+template <Frame frame, bool use_adaptive_directions>
 inline double Geometry ::get_shift(const Size o, const Size r, const Size c, const double Z) const {
-    Vector3D raydir                = rays.get_direction(o, r);
+    Vector3D raydir                = rays.get_direction<use_adaptive_directions>(o, r);
     const Vector3D origin          = points.position[o];
     const Vector3D origin_velocity = points.velocity[o];
     // Due to the old imager implementation, the computed shift might need to be

--- a/src/model/geometry/rays/rays.cpp
+++ b/src/model/geometry/rays/rays.cpp
@@ -86,23 +86,8 @@ void Rays ::write(const Io& io) const {
     io.write_list(prefix + "weight", weight);
 }
 
-// Size Rays ::get_direction_index(const Size pointidx, const Size rayidx) const {
-//     // if (!use_adaptive_directions) {
-//     //     return rayidx;
-//     // } else {
-//     return use_adaptive_directions * pointidx * parameters->nrays() + rayidx;
-//     // }
-// }
-
-
-// template <bool use_adaptive_directions>
-// Size Rays ::get_direction_index(const Size pointidx, const Size rayidx) const {
-//     if constexpr (use_adaptive_directions) {
-//         return pointidx * parameters->nrays() + rayidx;
-//     } else {
-//         return rayidx;
-//     }
-// }
+// Note: I can't seem to get constexpr to work correctly (linker error), thus manual template specialization instead
+// Note2: It might be that pybind11 expects the manual specialization, so all other template functions in this file are manually specialized
 
 template <>
 Size Rays ::get_direction_index<true>(const Size pointidx, const Size rayidx) const {
@@ -117,17 +102,33 @@ Size Rays ::get_direction_index<false>(const Size pointidx, const Size rayidx) c
 /// Get the direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <bool use_adaptive_directions>
-Vector3D Rays ::get_direction(const Size pointidx, const Size rayidx) const {
-    return direction[get_direction_index<use_adaptive_directions>(pointidx, rayidx)];
+template <>
+Vector3D Rays ::get_direction<true>(const Size pointidx, const Size rayidx) const {
+    return direction[get_direction_index<true>(pointidx, rayidx)];
+}
+
+/// Get the direction of a ray
+/// @param[in] pointidx: Index of the point
+/// @param[in] rayidx: Index of the ray
+template <>
+Vector3D Rays ::get_direction<false>(const Size pointidx, const Size rayidx) const {
+    return direction[get_direction_index<false>(pointidx, rayidx)];
 }
 
 /// Get the antipodal direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <bool use_adaptive_directions>
-Vector3D Rays ::get_antipod(const Size pointidx, const Size rayidx) const {
-    return direction[get_direction_index<use_adaptive_directions>(pointidx, get_antipod_index(rayidx))];
+template <>
+Vector3D Rays ::get_antipod<true>(const Size pointidx, const Size rayidx) const {
+    return direction[get_direction_index<true>(pointidx, get_antipod_index(rayidx))];
+}
+
+/// Get the antipodal direction of a ray
+/// @param[in] pointidx: Index of the point
+/// @param[in] rayidx: Index of the ray
+template <>
+Vector3D Rays ::get_antipod<false>(const Size pointidx, const Size rayidx) const {
+    return direction[get_direction_index<false>(pointidx, get_antipod_index(rayidx))];
 }
 
 /// Get the antipodal direction index
@@ -137,7 +138,15 @@ Size Rays ::get_antipod_index(const Size rayidx) const { return antipod[rayidx];
 /// Get the weight of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <bool use_adaptive_directions>
-Real Rays ::get_weight(const Size pointidx, const Size rayidx) const {
-    return weight[get_direction_index<use_adaptive_directions>(pointidx, rayidx)];
+template <>
+Real Rays ::get_weight<true>(const Size pointidx, const Size rayidx) const {
+    return weight[get_direction_index<true>(pointidx, rayidx)];
+}
+
+/// Get the weight of a ray
+/// @param[in] pointidx: Index of the point
+/// @param[in] rayidx: Index of the ray
+template <>
+Real Rays ::get_weight<false>(const Size pointidx, const Size rayidx) const {
+    return weight[get_direction_index<false>(pointidx, rayidx)];
 }

--- a/src/model/geometry/rays/rays.cpp
+++ b/src/model/geometry/rays/rays.cpp
@@ -5,21 +5,17 @@ const string prefix = "geometry/rays/";
 void Rays ::read(const Io& io) {
     cout << "Reading rays..." << endl;
 
-    parameters->set_nrays(
-        io.get_length(prefix + "antipod")); // unlike direction, antipod is of a fixed length nrays
-    parameters->set_hnrays(parameters->nrays() / 2);
-
     Size len_dir =
         io.get_length(prefix + "direction"); // length of first axis of the direction array
+
     if (len_dir == parameters->nrays()) {
+        parameters->set_hnrays(parameters->nrays() / 2);
         use_adaptive_directions = false;
     } else if (len_dir == parameters->nrays() * parameters->npoints()) {
+        parameters->set_hnrays(parameters->nrays() / 2);
         use_adaptive_directions = true;
     } else {
-        cout
-            << "Error: The length of the direction array is not compatible with the number of rays."
-            << endl;
-        exit(1);
+        parameters->set_nrays(len_dir);//will error, and give some more info on the sizes of the arrays
     }
 
     antipod.resize(parameters->nrays());
@@ -37,7 +33,7 @@ void Rays ::read(const Io& io) {
             direction[r] =
                 Vector3D(direction_buffer[r][0], direction_buffer[r][1], direction_buffer[r][2]);
         }
-    } else {
+    } else {//use adaptive directions == true
         weight.resize(parameters->nrays() * parameters->npoints());
         io.read_list(prefix + "weight", weight);
 

--- a/src/model/geometry/rays/rays.cpp
+++ b/src/model/geometry/rays/rays.cpp
@@ -86,26 +86,38 @@ void Rays ::write(const Io& io) const {
     io.write_list(prefix + "weight", weight);
 }
 
+// Size Rays ::get_direction_index(const Size pointidx, const Size rayidx) const {
+//     // if (!use_adaptive_directions) {
+//     //     return rayidx;
+//     // } else {
+//     return use_adaptive_directions * pointidx * parameters->nrays() + rayidx;
+//     // }
+// }
+
+
+template <bool use_adaptive_directions>
 Size Rays ::get_direction_index(const Size pointidx, const Size rayidx) const {
-    if (!use_adaptive_directions) {
-        return rayidx;
-    } else {
+    if constexpr (use_adaptive_directions) {
         return pointidx * parameters->nrays() + rayidx;
+    } else {
+        return rayidx;
     }
 }
 
 /// Get the direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
+template <bool use_adaptive_directions>
 Vector3D Rays ::get_direction(const Size pointidx, const Size rayidx) const {
-    return direction[get_direction_index(pointidx, rayidx)];
+    return direction[get_direction_index<use_adaptive_directions>(pointidx, rayidx)];
 }
 
 /// Get the antipodal direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
+template <bool use_adaptive_directions>
 Vector3D Rays ::get_antipod(const Size pointidx, const Size rayidx) const {
-    return direction[get_direction_index(pointidx, get_antipod_index(rayidx))];
+    return direction[get_direction_index<use_adaptive_directions>(pointidx, get_antipod_index(rayidx))];
 }
 
 /// Get the antipodal direction index
@@ -115,6 +127,7 @@ Size Rays ::get_antipod_index(const Size rayidx) const { return antipod[rayidx];
 /// Get the weight of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
+template <bool use_adaptive_directions>
 Real Rays ::get_weight(const Size pointidx, const Size rayidx) const {
-    return weight[get_direction_index(pointidx, rayidx)];
+    return weight[get_direction_index<use_adaptive_directions>(pointidx, rayidx)];
 }

--- a/src/model/geometry/rays/rays.cpp
+++ b/src/model/geometry/rays/rays.cpp
@@ -5,25 +5,56 @@ const string prefix = "geometry/rays/";
 void Rays ::read(const Io& io) {
     cout << "Reading rays..." << endl;
 
-    parameters->set_nrays(io.get_length(prefix + "direction"));
+    parameters->set_nrays(
+        io.get_length(prefix + "antipod")); // unlike direction, antipod is of a fixed length nrays
     parameters->set_hnrays(parameters->nrays() / 2);
 
-    direction.resize(parameters->nrays());
+    Size len_dir =
+        io.get_length(prefix + "direction"); // length of first axis of the direction array
+    if (len_dir == parameters->nrays()) {
+        use_adaptive_directions = false;
+    } else if (len_dir == parameters->nrays() * parameters->npoints()) {
+        use_adaptive_directions = true;
+    } else {
+        cout
+            << "Error: The length of the direction array is not compatible with the number of rays."
+            << endl;
+        exit(1);
+    }
+
     antipod.resize(parameters->nrays());
-    weight.resize(parameters->nrays());
 
-    Double2 direction_buffer(parameters->nrays(), Double1(3));
+    if (!use_adaptive_directions) {
+        weight.resize(parameters->nrays());
+        io.read_list(prefix + "weight", weight);
 
-    io.read_array(prefix + "direction", direction_buffer);
-    io.read_list(prefix + "weight", weight);
+        direction.resize(parameters->nrays());
+        Double2 direction_buffer(parameters->nrays(), Double1(3));
 
-    for (Size r = 0; r < parameters->nrays(); r++) {
-        direction[r] =
-            Vector3D(direction_buffer[r][0], direction_buffer[r][1], direction_buffer[r][2]);
+        io.read_array(prefix + "direction", direction_buffer);
+
+        for (Size r = 0; r < parameters->nrays(); r++) {
+            direction[r] =
+                Vector3D(direction_buffer[r][0], direction_buffer[r][1], direction_buffer[r][2]);
+        }
+    } else {
+        weight.resize(parameters->nrays() * parameters->npoints());
+        io.read_list(prefix + "weight", weight);
+
+        direction.resize(parameters->nrays() * parameters->npoints());
+        Double2 direction_buffer(parameters->nrays() * parameters->npoints(), Double1(3));
+
+        io.read_array(prefix + "direction", direction_buffer);
+
+        for (Size r = 0; r < parameters->nrays() * parameters->npoints(); r++) {
+            direction[r] =
+                Vector3D(direction_buffer[r][0], direction_buffer[r][1], direction_buffer[r][2]);
+        }
     }
 
     const double tolerance = 1.0E-9;
 
+    // We assume the antipod index to remain the same for all points
     for (Size r1 = 0; r1 < parameters->nrays(); r1++) {
         for (Size r2 = 0; r2 < parameters->nrays(); r2++) {
             if ((direction[r1] + direction[r2]).squaredNorm() < tolerance) {
@@ -40,12 +71,54 @@ void Rays ::read(const Io& io) {
 void Rays ::write(const Io& io) const {
     cout << "Writing rays..." << endl;
 
-    Double2 direction_buffer(parameters->nrays(), Double1(3));
+    if (!use_adaptive_directions) {
+        Double2 direction_buffer(parameters->nrays(), Double1(3));
 
-    for (Size r = 0; r < parameters->nrays(); r++) {
-        direction_buffer[r] = {direction[r].x(), direction[r].y(), direction[r].z()};
+        for (Size r = 0; r < parameters->nrays(); r++) {
+            direction_buffer[r] = {direction[r].x(), direction[r].y(), direction[r].z()};
+        }
+        io.write_array(prefix + "direction", direction_buffer);
+    } else {
+        Double2 direction_buffer(parameters->nrays() * parameters->npoints(), Double1(3));
+
+        for (Size r = 0; r < parameters->nrays() * parameters->npoints(); r++) {
+            direction_buffer[r] = {direction[r].x(), direction[r].y(), direction[r].z()};
+        }
+        io.write_array(prefix + "direction", direction_buffer);
     }
 
-    io.write_array(prefix + "direction", direction_buffer);
     io.write_list(prefix + "weight", weight);
+}
+
+Size Rays ::get_direction_index(const Size pointidx, const Size rayidx) const {
+    if (!use_adaptive_directions) {
+        return rayidx;
+    } else {
+        return pointidx * parameters->nrays() + rayidx;
+    }
+}
+
+/// Get the direction of a ray
+/// @param[in] pointidx: Index of the point
+/// @param[in] rayidx: Index of the ray
+Vector3D Rays ::get_direction(const Size pointidx, const Size rayidx) const {
+    return direction[get_direction_index(pointidx, rayidx)];
+}
+
+/// Get the antipodal direction of a ray
+/// @param[in] pointidx: Index of the point
+/// @param[in] rayidx: Index of the ray
+Vector3D Rays ::get_antipod(const Size pointidx, const Size rayidx) const {
+    return direction[get_direction_index(pointidx, get_antipod_index(rayidx))];
+}
+
+/// Get the antipodal direction index
+/// @param[in] rayidx: Index of the ray
+Size Rays ::get_antipod_index(const Size rayidx) const { return antipod[rayidx]; }
+
+/// Get the weight of a ray
+/// @param[in] pointidx: Index of the point
+/// @param[in] rayidx: Index of the ray
+Real Rays ::get_weight(const Size pointidx, const Size rayidx) const {
+    return weight[get_direction_index(pointidx, rayidx)];
 }

--- a/src/model/geometry/rays/rays.cpp
+++ b/src/model/geometry/rays/rays.cpp
@@ -95,13 +95,23 @@ void Rays ::write(const Io& io) const {
 // }
 
 
-template <bool use_adaptive_directions>
-Size Rays ::get_direction_index(const Size pointidx, const Size rayidx) const {
-    if constexpr (use_adaptive_directions) {
-        return pointidx * parameters->nrays() + rayidx;
-    } else {
-        return rayidx;
-    }
+// template <bool use_adaptive_directions>
+// Size Rays ::get_direction_index(const Size pointidx, const Size rayidx) const {
+//     if constexpr (use_adaptive_directions) {
+//         return pointidx * parameters->nrays() + rayidx;
+//     } else {
+//         return rayidx;
+//     }
+// }
+
+template <>
+Size Rays ::get_direction_index<true>(const Size pointidx, const Size rayidx) const {
+    return pointidx * parameters->nrays() + rayidx;
+}
+
+template <>
+Size Rays ::get_direction_index<false>(const Size pointidx, const Size rayidx) const {
+    return rayidx;
 }
 
 /// Get the direction of a ray

--- a/src/model/geometry/rays/rays.cpp
+++ b/src/model/geometry/rays/rays.cpp
@@ -15,7 +15,8 @@ void Rays ::read(const Io& io) {
         parameters->set_hnrays(parameters->nrays() / 2);
         use_adaptive_directions = true;
     } else {
-        parameters->set_nrays(len_dir);//will error, and give some more info on the sizes of the arrays
+        parameters->set_nrays(
+            len_dir); // will error, and give some more info on the sizes of the arrays
     }
 
     antipod.resize(parameters->nrays());
@@ -33,7 +34,7 @@ void Rays ::read(const Io& io) {
             direction[r] =
                 Vector3D(direction_buffer[r][0], direction_buffer[r][1], direction_buffer[r][2]);
         }
-    } else {//use adaptive directions == true
+    } else { // use adaptive directions == true
         weight.resize(parameters->nrays() * parameters->npoints());
         io.read_list(prefix + "weight", weight);
 
@@ -86,48 +87,43 @@ void Rays ::write(const Io& io) const {
     io.write_list(prefix + "weight", weight);
 }
 
-// Note: I can't seem to get constexpr to work correctly (linker error), thus manual template specialization instead
-// Note2: It might be that pybind11 expects the manual specialization, so all other template functions in this file are manually specialized
+// Note: I can't seem to get constexpr to work correctly (linker error), thus manual template
+// specialization instead Note2: It might be that pybind11 expects the manual specialization, so all
+// other template functions in this file are manually specialized
 
-template <>
-Size Rays ::get_direction_index<true>(const Size pointidx, const Size rayidx) const {
+template <> Size Rays ::get_direction_index<true>(const Size pointidx, const Size rayidx) const {
     return pointidx * parameters->nrays() + rayidx;
 }
 
-template <>
-Size Rays ::get_direction_index<false>(const Size pointidx, const Size rayidx) const {
+template <> Size Rays ::get_direction_index<false>(const Size pointidx, const Size rayidx) const {
     return rayidx;
 }
 
 /// Get the direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <>
-Vector3D Rays ::get_direction<true>(const Size pointidx, const Size rayidx) const {
+template <> Vector3D Rays ::get_direction<true>(const Size pointidx, const Size rayidx) const {
     return direction[get_direction_index<true>(pointidx, rayidx)];
 }
 
 /// Get the direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <>
-Vector3D Rays ::get_direction<false>(const Size pointidx, const Size rayidx) const {
+template <> Vector3D Rays ::get_direction<false>(const Size pointidx, const Size rayidx) const {
     return direction[get_direction_index<false>(pointidx, rayidx)];
 }
 
 /// Get the antipodal direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <>
-Vector3D Rays ::get_antipod<true>(const Size pointidx, const Size rayidx) const {
+template <> Vector3D Rays ::get_antipod<true>(const Size pointidx, const Size rayidx) const {
     return direction[get_direction_index<true>(pointidx, get_antipod_index(rayidx))];
 }
 
 /// Get the antipodal direction of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <>
-Vector3D Rays ::get_antipod<false>(const Size pointidx, const Size rayidx) const {
+template <> Vector3D Rays ::get_antipod<false>(const Size pointidx, const Size rayidx) const {
     return direction[get_direction_index<false>(pointidx, get_antipod_index(rayidx))];
 }
 
@@ -138,15 +134,13 @@ Size Rays ::get_antipod_index(const Size rayidx) const { return antipod[rayidx];
 /// Get the weight of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <>
-Real Rays ::get_weight<true>(const Size pointidx, const Size rayidx) const {
+template <> Real Rays ::get_weight<true>(const Size pointidx, const Size rayidx) const {
     return weight[get_direction_index<true>(pointidx, rayidx)];
 }
 
 /// Get the weight of a ray
 /// @param[in] pointidx: Index of the point
 /// @param[in] rayidx: Index of the ray
-template <>
-Real Rays ::get_weight<false>(const Size pointidx, const Size rayidx) const {
+template <> Real Rays ::get_weight<false>(const Size pointidx, const Size rayidx) const {
     return weight[get_direction_index<false>(pointidx, rayidx)];
 }

--- a/src/model/geometry/rays/rays.hpp
+++ b/src/model/geometry/rays/rays.hpp
@@ -20,10 +20,14 @@ struct Rays {
     void read(const Io& io);
     void write(const Io& io) const;
 
+    template <bool use_adaptive_directions>
     Size get_direction_index(
         const Size pointidx, const Size rayidx) const; // linearized direction index
+    template <bool use_adaptive_directions>
     Vector3D get_direction(const Size pointidx, const Size rayidx) const;
+    template <bool use_adaptive_directions>
     Vector3D get_antipod(const Size pointidx, const Size rayidx) const;
     Size get_antipod_index(const Size rayidx) const;
+    template <bool use_adaptive_directions>
     Real get_weight(const Size pointidx, const Size rayidx) const;
 };

--- a/src/model/geometry/rays/rays.hpp
+++ b/src/model/geometry/rays/rays.hpp
@@ -7,12 +7,23 @@
 struct Rays {
     std::shared_ptr<Parameters> parameters;
 
-    Vector<Vector3D> direction;
-    Vector<Size> antipod;
-    Vector<Real> weight;
+    Vector<Vector3D> direction; // Direction Can either have dimensions [Nrays, 3] or
+                                // [Nrays*Npoints, 3], in order to keep backward compatibility
+    Vector<Size> antipod;       // Opposite direction index; assume to be the same for all points;
+                                // dimensions [Nrays]
+    Vector<Real> weight;        // Weight of each ray; dimensions [Nrays, 3] or [Nrays*Npoints, 3]
+    bool use_adaptive_directions =
+        false; // Whether to use a different set of directions for each ray
 
     Rays(std::shared_ptr<Parameters> params) : parameters(params){};
 
     void read(const Io& io);
     void write(const Io& io) const;
+
+    Size get_direction_index(
+        const Size pointidx, const Size rayidx) const; // linearized direction index
+    Vector3D get_direction(const Size pointidx, const Size rayidx) const;
+    Vector3D get_antipod(const Size pointidx, const Size rayidx) const;
+    Size get_antipod_index(const Size rayidx) const;
+    Real get_weight(const Size pointidx, const Size rayidx) const;
 };

--- a/src/model/image/image.cpp
+++ b/src/model/image/image.cpp
@@ -13,9 +13,9 @@ Image ::Image(
     const Geometry& geometry, const Frequencies& frequencies, const ImageType it, const Size rr) :
     imageType(it),
     imagePointPosition(AllModelPoints), ray_nr(rr),
-    ray_direction(Vector3D(geometry.rays.get_direction(0, ray_nr))) {
+    ray_direction(Vector3D(geometry.rays.get_direction<false>(0, ray_nr))) {
     if (geometry.parameters->dimension() == 1) {
-        const Vector3D raydir = geometry.rays.get_direction(0, ray_nr);
+        const Vector3D raydir = geometry.rays.get_direction<false>(0, ray_nr);
         if ((raydir.x() != 0.0) || (raydir.y() != 1.0) || (raydir.z() != 0.0)) {
             throw std::runtime_error("In 1D, the image ray has to be (0,1,0)");
         }
@@ -31,9 +31,9 @@ Image ::Image(const Geometry& geometry, const Frequencies& frequencies, const Im
     const Size rr, const Size Nxpix, const Size Nypix) :
     imageType(it),
     imagePointPosition(ProjectionSurface), ray_nr(rr),
-    ray_direction(Vector3D(geometry.rays.get_direction(0, ray_nr))) {
+    ray_direction(Vector3D(geometry.rays.get_direction<false>(0, ray_nr))) {
     if (geometry.parameters->dimension() == 1) {
-        const Vector3D raydir = geometry.rays.get_direction(0, ray_nr);
+        const Vector3D raydir = geometry.rays.get_direction<false>(0, ray_nr);
         if ((raydir.x() != 0.0) || (raydir.y() != 1.0) || (raydir.z() != 0.0)) {
             throw std::runtime_error("In 1D, the image ray has to be (0,1,0)");
         }

--- a/src/model/image/image.cpp
+++ b/src/model/image/image.cpp
@@ -13,11 +13,10 @@ Image ::Image(
     const Geometry& geometry, const Frequencies& frequencies, const ImageType it, const Size rr) :
     imageType(it),
     imagePointPosition(AllModelPoints), ray_nr(rr),
-    ray_direction(Vector3D(geometry.rays.direction[ray_nr])) {
+    ray_direction(Vector3D(geometry.rays.get_direction(0, ray_nr))) {
     if (geometry.parameters->dimension() == 1) {
-        if ((geometry.rays.direction[ray_nr].x() != 0.0)
-            || (geometry.rays.direction[ray_nr].y() != 1.0)
-            || (geometry.rays.direction[ray_nr].z() != 0.0)) {
+        const Vector3D raydir = geometry.rays.get_direction(0, ray_nr);
+        if ((raydir.x() != 0.0) || (raydir.y() != 1.0) || (raydir.z() != 0.0)) {
             throw std::runtime_error("In 1D, the image ray has to be (0,1,0)");
         }
     }
@@ -32,11 +31,10 @@ Image ::Image(const Geometry& geometry, const Frequencies& frequencies, const Im
     const Size rr, const Size Nxpix, const Size Nypix) :
     imageType(it),
     imagePointPosition(ProjectionSurface), ray_nr(rr),
-    ray_direction(Vector3D(geometry.rays.direction[ray_nr])) {
+    ray_direction(Vector3D(geometry.rays.get_direction(0, ray_nr))) {
     if (geometry.parameters->dimension() == 1) {
-        if ((geometry.rays.direction[ray_nr].x() != 0.0)
-            || (geometry.rays.direction[ray_nr].y() != 1.0)
-            || (geometry.rays.direction[ray_nr].z() != 0.0)) {
+        const Vector3D raydir = geometry.rays.get_direction(0, ray_nr);
+        if ((raydir.x() != 0.0) || (raydir.y() != 1.0) || (raydir.z() != 0.0)) {
             throw std::runtime_error("In 1D, the image ray has to be (0,1,0)");
         }
     }
@@ -173,9 +171,9 @@ inline void Image ::set_coordinates_all_model_points(const Geometry& geometry) {
     }
 
     if (geometry.parameters->dimension() == 3) {
-        const double rx = geometry.rays.direction[ray_nr].x();
-        const double ry = geometry.rays.direction[ray_nr].y();
-        const double rz = geometry.rays.direction[ray_nr].z();
+        const double rx = ray_direction.x();
+        const double ry = ray_direction.y();
+        const double rz = ray_direction.z();
 
         const double denominator         = sqrt(rx * rx + ry * ry);
         const double inverse_denominator = 1.0 / denominator;

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -314,19 +314,38 @@ int Model ::compute_radiation_field_shortchar_order_0() {
     cout << "Computing radiation field..." << endl;
 
     Solver solver;
-    solver.setup<CoMoving>(*this);
+    const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
+    //TODO: create macro for this substitution instead of doing the if-else manually
+    if (use_adaptive_directions) {
+        cout << "Using adaptive directions" << endl;
+        solver.setup<CoMoving, true>(*this);
+    }
+    else {
+        solver.setup<CoMoving, false>(*this);
+    }
 
     if (parameters->one_line_approximation) {
-        solver.solve_shortchar_order_0<OneLine>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_shortchar_order_0<OneLine, true>(*this);
+        } else {
+            solver.solve_shortchar_order_0<OneLine, false>(*this);
+        }
         return (0);
     }
 
     if (parameters->sum_opacity_emissivity_over_all_lines) {
-        solver.solve_shortchar_order_0<None>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_shortchar_order_0<None, true>(*this);
+        } else {
+            solver.solve_shortchar_order_0<None, false>(*this);
+        }
         return (0);
     }
-
-    solver.solve_shortchar_order_0<CloseLines>(*this);
+    if (use_adaptive_directions) {
+        solver.solve_shortchar_order_0<CloseLines, true>(*this);
+    } else {
+        solver.solve_shortchar_order_0<CloseLines, false>(*this);
+    }
     return (0);
 }
 
@@ -336,19 +355,39 @@ int Model ::compute_radiation_field_feautrier_order_2() {
     cout << "Computing radiation field..." << endl;
 
     Solver solver;
-    solver.setup<CoMoving>(*this);
+    const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
+    //TODO: create macro for this substitution instead of doing the if-else manually
+    if (use_adaptive_directions) {
+        cout << "Using adaptive directions" << endl;
+        solver.setup<CoMoving, true>(*this);
+    }
+    else {
+        solver.setup<CoMoving, false>(*this);
+    }
 
     if (parameters->one_line_approximation) {
-        solver.solve_feautrier_order_2<OneLine>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2<OneLine, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2<OneLine, false>(*this);
+        }
         return (0);
     }
 
     if (parameters->sum_opacity_emissivity_over_all_lines) {
-        solver.solve_feautrier_order_2<None>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2<None, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2<None, false>(*this);
+        }
         return (0);
     }
 
-    solver.solve_feautrier_order_2<CloseLines>(*this);
+    if (use_adaptive_directions) {
+        solver.solve_feautrier_order_2<CloseLines, true>(*this);
+    } else {
+        solver.solve_feautrier_order_2<CloseLines, false>(*this);
+    }
     return (0);
 }
 
@@ -359,19 +398,38 @@ int Model ::compute_radiation_field_feautrier_order_2_uv() {
     cout << "Computing radiation field..." << endl;
 
     Solver solver;
-    solver.setup<CoMoving>(*this);
+    const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
+    if (use_adaptive_directions) {
+        cout << "Using adaptive directions" << endl;
+        solver.setup<CoMoving, true>(*this);
+    }
+    else {
+        solver.setup<CoMoving, false>(*this);
+    }
 
     if (parameters->one_line_approximation) {
-        solver.solve_feautrier_order_2_uv<OneLine>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2_uv<OneLine, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2_uv<OneLine, false>(*this);
+        }
         return (0);
     }
 
     if (parameters->sum_opacity_emissivity_over_all_lines) {
-        solver.solve_feautrier_order_2_uv<None>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2_uv<None, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2_uv<None, false>(*this);
+        }
         return (0);
     }
 
-    solver.solve_feautrier_order_2_uv<CloseLines>(*this);
+    if (use_adaptive_directions) {
+        solver.solve_feautrier_order_2_uv<CloseLines, true>(*this);
+    } else {
+        solver.solve_feautrier_order_2_uv<CloseLines, false>(*this);
+    }
     return (0);
 }
 
@@ -381,19 +439,37 @@ int Model ::compute_radiation_field_feautrier_order_2_anis() {
     cout << "Computing radiation field..." << endl;
 
     Solver solver;
-    solver.setup<CoMoving>(*this);
+    const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
+    if (use_adaptive_directions) {
+        cout << "Using adaptive directions" << endl;
+        solver.setup<CoMoving, true>(*this);
+    }
+    else {
+        solver.setup<CoMoving, false>(*this);
+    }
 
     if (parameters->one_line_approximation) {
-        solver.solve_feautrier_order_2_anis<OneLine>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2_anis<OneLine, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2_anis<OneLine, false>(*this);
+        }
         return (0);
     }
 
     if (parameters->sum_opacity_emissivity_over_all_lines) {
-        solver.solve_feautrier_order_2_anis<None>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2_anis<None, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2_anis<None, false>(*this);
+        }
         return (0);
     }
-
-    solver.solve_feautrier_order_2_anis<CloseLines>(*this);
+    if (use_adaptive_directions) {
+        solver.solve_feautrier_order_2_anis<CloseLines, true>(*this);
+    } else {
+        solver.solve_feautrier_order_2_anis<CloseLines, false>(*this);
+    }
     return (0);
 }
 
@@ -403,19 +479,38 @@ int Model ::compute_radiation_field_feautrier_order_2_sparse() {
     cout << "Computing radiation field..." << endl;
 
     Solver solver;
-    solver.setup<CoMoving>(*this);
+    const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
+    if (use_adaptive_directions) {
+        cout << "Using adaptive directions" << endl;
+        solver.setup<CoMoving, true>(*this);
+    }
+    else {
+        solver.setup<CoMoving, false>(*this);
+    }
 
     if (parameters->one_line_approximation) {
-        solver.solve_feautrier_order_2_sparse<OneLine>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2_sparse<OneLine, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2_sparse<OneLine, false>(*this);
+        }
         return (0);
     }
 
     if (parameters->sum_opacity_emissivity_over_all_lines) {
-        solver.solve_feautrier_order_2_sparse<None>(*this);
+        if (use_adaptive_directions) {
+            solver.solve_feautrier_order_2_sparse<None, true>(*this);
+        } else {
+            solver.solve_feautrier_order_2_sparse<None, false>(*this);
+        }
         return (0);
     }
 
-    solver.solve_feautrier_order_2_sparse<CloseLines>(*this);
+    if (use_adaptive_directions) {
+        solver.solve_feautrier_order_2_sparse<CloseLines, true>(*this);
+    } else {
+        solver.solve_feautrier_order_2_sparse<CloseLines, false>(*this);
+    }
     return (0);
 }
 
@@ -868,7 +963,8 @@ int Model ::compute_image(const Size ray_nr) {
     cout << "Computing image..." << endl;
 
     Solver solver;
-    solver.setup<Rest>(*this);
+    solver.setup<Rest, false>(*this);
+
     if (parameters->one_line_approximation) {
         throw std::runtime_error("One line approximation is currently not supported for imaging.");
         solver.image_feautrier_order_2<OneLine>(*this, ray_nr);
@@ -894,13 +990,13 @@ int Model ::compute_image(const Size ray_nr) {
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_new(const Size ray_nr) {
-    return compute_image_new(geometry.rays.get_direction(0, ray_nr), 256, 256);
+    return compute_image_new(geometry.rays.get_direction<false>(0, ray_nr), 256, 256);
 }
 
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_new(const Size ray_nr, const Size Nxpix, const Size Nypix) {
-    return compute_image_new(geometry.rays.get_direction(0, ray_nr), Nxpix, Nypix);
+    return compute_image_new(geometry.rays.get_direction<false>(0, ray_nr), Nxpix, Nypix);
 }
 
 ///  Wrapper for the new imager
@@ -949,7 +1045,7 @@ int Model ::compute_image_for_point(const Size ray_nr, const Size p) {
     cout << "Computing image for point " << p << "..." << endl;
 
     Solver solver;
-    solver.setup<Rest>(*this);
+    solver.setup<Rest, false>(*this);
     if (parameters->one_line_approximation) {
         throw std::runtime_error("One line approximation is currently not supported for imaging.");
         solver.image_feautrier_order_2_for_point<OneLine>(*this, ray_nr, p);
@@ -969,7 +1065,7 @@ int Model ::compute_image_for_point(const Size ray_nr, const Size p) {
 //////////////////////////////////////
 int Model ::compute_image_optical_depth(const Size ray_nr) {
     Solver solver;
-    solver.setup<Rest>(*this);
+    solver.setup<Rest, false>(*this);
     if (parameters->one_line_approximation) {
         throw std::runtime_error("One line approximation is currently not supported for imaging.");
         solver.image_optical_depth<OneLine>(*this, ray_nr);
@@ -988,13 +1084,13 @@ int Model ::compute_image_optical_depth(const Size ray_nr) {
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_optical_depth_new(const Size ray_nr) {
-    return compute_image_optical_depth_new(geometry.rays.get_direction(0, ray_nr), 256, 256);
+    return compute_image_optical_depth_new(geometry.rays.get_direction<false>(0, ray_nr), 256, 256);
 }
 
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_optical_depth_new(const Size ray_nr, const Size Nxpix, const Size Nypix) {
-    return compute_image_optical_depth_new(geometry.rays.get_direction(0, ray_nr), Nxpix, Nypix);
+    return compute_image_optical_depth_new(geometry.rays.get_direction<false>(0, ray_nr), Nxpix, Nypix);
 }
 
 ///  Wrapper for the new imager
@@ -1050,7 +1146,14 @@ int Model ::set_boundary_condition() {
 
 int Model ::set_column() {
     Solver solver;
-    solver.set_column(*this);
+    const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
+    if (use_adaptive_directions) {
+        cout << "Using adaptive directions" << endl;
+        solver.set_column<true>(*this);
+    }
+    else {
+        solver.set_column<false>(*this);
+    }
 
     return (0);
 }

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -315,12 +315,11 @@ int Model ::compute_radiation_field_shortchar_order_0() {
 
     Solver solver;
     const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
-    //TODO: create macro for this substitution instead of doing the if-else manually
+    // TODO: create macro for this substitution instead of doing the if-else manually
     if (use_adaptive_directions) {
         cout << "Using adaptive directions" << endl;
         solver.setup<CoMoving, true>(*this);
-    }
-    else {
+    } else {
         solver.setup<CoMoving, false>(*this);
     }
 
@@ -356,12 +355,11 @@ int Model ::compute_radiation_field_feautrier_order_2() {
 
     Solver solver;
     const bool use_adaptive_directions = geometry.rays.use_adaptive_directions;
-    //TODO: create macro for this substitution instead of doing the if-else manually
+    // TODO: create macro for this substitution instead of doing the if-else manually
     if (use_adaptive_directions) {
         cout << "Using adaptive directions" << endl;
         solver.setup<CoMoving, true>(*this);
-    }
-    else {
+    } else {
         solver.setup<CoMoving, false>(*this);
     }
 
@@ -402,8 +400,7 @@ int Model ::compute_radiation_field_feautrier_order_2_uv() {
     if (use_adaptive_directions) {
         cout << "Using adaptive directions" << endl;
         solver.setup<CoMoving, true>(*this);
-    }
-    else {
+    } else {
         solver.setup<CoMoving, false>(*this);
     }
 
@@ -443,8 +440,7 @@ int Model ::compute_radiation_field_feautrier_order_2_anis() {
     if (use_adaptive_directions) {
         cout << "Using adaptive directions" << endl;
         solver.setup<CoMoving, true>(*this);
-    }
-    else {
+    } else {
         solver.setup<CoMoving, false>(*this);
     }
 
@@ -483,8 +479,7 @@ int Model ::compute_radiation_field_feautrier_order_2_sparse() {
     if (use_adaptive_directions) {
         cout << "Using adaptive directions" << endl;
         solver.setup<CoMoving, true>(*this);
-    }
-    else {
+    } else {
         solver.setup<CoMoving, false>(*this);
     }
 
@@ -1090,7 +1085,8 @@ int Model ::compute_image_optical_depth_new(const Size ray_nr) {
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_optical_depth_new(const Size ray_nr, const Size Nxpix, const Size Nypix) {
-    return compute_image_optical_depth_new(geometry.rays.get_direction<false>(0, ray_nr), Nxpix, Nypix);
+    return compute_image_optical_depth_new(
+        geometry.rays.get_direction<false>(0, ray_nr), Nxpix, Nypix);
 }
 
 ///  Wrapper for the new imager
@@ -1150,8 +1146,7 @@ int Model ::set_column() {
     if (use_adaptive_directions) {
         cout << "Using adaptive directions" << endl;
         solver.set_column<true>(*this);
-    }
-    else {
+    } else {
         solver.set_column<false>(*this);
     }
 

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -894,13 +894,13 @@ int Model ::compute_image(const Size ray_nr) {
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_new(const Size ray_nr) {
-    return compute_image_new(geometry.rays.direction[ray_nr], 256, 256);
+    return compute_image_new(geometry.rays.get_direction(0, ray_nr), 256, 256);
 }
 
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_new(const Size ray_nr, const Size Nxpix, const Size Nypix) {
-    return compute_image_new(geometry.rays.direction[ray_nr], Nxpix, Nypix);
+    return compute_image_new(geometry.rays.get_direction(0, ray_nr), Nxpix, Nypix);
 }
 
 ///  Wrapper for the new imager
@@ -988,13 +988,13 @@ int Model ::compute_image_optical_depth(const Size ray_nr) {
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_optical_depth_new(const Size ray_nr) {
-    return compute_image_optical_depth_new(geometry.rays.direction[ray_nr], 256, 256);
+    return compute_image_optical_depth_new(geometry.rays.get_direction(0, ray_nr), 256, 256);
 }
 
 ///  Wrapper for the new imager
 ///////////////////////////////
 int Model ::compute_image_optical_depth_new(const Size ray_nr, const Size Nxpix, const Size Nypix) {
-    return compute_image_optical_depth_new(geometry.rays.direction[ray_nr], Nxpix, Nypix);
+    return compute_image_optical_depth_new(geometry.rays.get_direction(0, ray_nr), Nxpix, Nypix);
 }
 
 ///  Wrapper for the new imager

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -69,7 +69,7 @@ struct Solver {
 
     Size n_off_diag;
 
-    template <Frame frame> void setup(Model& model);
+    template <Frame frame, bool use_adaptive_directions> void setup(Model& model);
 
     // template <Frame frame>
     void setup_new_imager(Model& model, Image& image, const Vector3D& ray_dir);
@@ -78,9 +78,9 @@ struct Solver {
 
     accel inline Real get_dshift_max(const Model& model, const Size o);
 
-    template <Frame frame> inline void get_ray_lengths(Model& model);
+    template <Frame frame, bool use_adaptive_directions> inline void get_ray_lengths(Model& model);
 
-    template <Frame frame> inline Size get_ray_lengths_max(Model& model);
+    template <Frame frame, bool use_adaptive_directions> inline Size get_ray_lengths_max(Model& model);
 
     // template <Frame frame>
     inline Size get_ray_lengths_max_new_imager(Model& model, Image& image, const Vector3D& ray_dir);
@@ -88,7 +88,7 @@ struct Solver {
     accel inline Size get_ray_length_new_imager(const Geometry& geometry, const Vector3D& origin,
         const Size start_bdy, const Vector3D& raydir);
 
-    template <Frame frame>
+    template <Frame frame, bool use_adaptive_directions>
     accel inline Size trace_ray(const Geometry& geometry, const Size o, const Size r,
         const double dshift_max, const int increment, Size id1, Size id2);
 
@@ -126,7 +126,7 @@ struct Solver {
         bool& compute_curr_opacity, Real& dtaunext, Real& chicurr, Real& chinext, Real& Scurr,
         Real& Snext);
 
-    template <ApproximationType approx>
+    template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void update_Lambda(Model& model, const Size rr, const Size f);
     // accel inline void solve_shortchar_order_0_ray_forward (
     //           Model& model,
@@ -168,12 +168,13 @@ struct Solver {
 
     // Solvers only computing u
     ///////////////////////////
-    template <ApproximationType approx> accel inline void solve_feautrier_order_2(Model& model);
+    template <ApproximationType approx, bool use_adaptive_directions> 
+    accel inline void solve_feautrier_order_2(Model& model);
 
-    template <ApproximationType approx>
+    template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void solve_feautrier_order_2_sparse(Model& model);
 
-    template <ApproximationType approx>
+    template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void solve_feautrier_order_2_anis(Model& model);
 
     template <ApproximationType approx>
@@ -182,12 +183,13 @@ struct Solver {
     // // Solvers for both u and v
     // ///////////////////////////
 
-    template <ApproximationType approx> accel inline void solve_shortchar_order_0(Model& model);
-    template <ApproximationType approx>
+    template <ApproximationType approx, bool use_adaptive_directions>
+    accel inline void solve_shortchar_order_0(Model& model);
+    template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void solve_shortchar_order_0(Model& model, const Size o, const Size r);
 
-    /// BUGGED: v computation is incorrect
-    template <ApproximationType approx> accel inline void solve_feautrier_order_2_uv(Model& model);
+    template <ApproximationType approx, bool use_adaptive_directions>
+    accel inline void solve_feautrier_order_2_uv(Model& model);
 
     template <ApproximationType approx>
     accel inline void solve_feautrier_order_2_uv(Model& model, const Size o, const Size f);
@@ -200,7 +202,9 @@ struct Solver {
 
     // Solvers for column densities
     ///////////////////////////////
+    template <bool use_adaptive_directions>
     accel inline void set_column(Model& model) const;
+    template <bool use_adaptive_directions>
     accel inline Real get_column(const Model& model, const Size o, const Size r) const;
 };
 

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -80,7 +80,8 @@ struct Solver {
 
     template <Frame frame, bool use_adaptive_directions> inline void get_ray_lengths(Model& model);
 
-    template <Frame frame, bool use_adaptive_directions> inline Size get_ray_lengths_max(Model& model);
+    template <Frame frame, bool use_adaptive_directions>
+    inline Size get_ray_lengths_max(Model& model);
 
     // template <Frame frame>
     inline Size get_ray_lengths_max_new_imager(Model& model, Image& image, const Vector3D& ray_dir);
@@ -168,7 +169,7 @@ struct Solver {
 
     // Solvers only computing u
     ///////////////////////////
-    template <ApproximationType approx, bool use_adaptive_directions> 
+    template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void solve_feautrier_order_2(Model& model);
 
     template <ApproximationType approx, bool use_adaptive_directions>
@@ -202,8 +203,7 @@ struct Solver {
 
     // Solvers for column densities
     ///////////////////////////////
-    template <bool use_adaptive_directions>
-    accel inline void set_column(Model& model) const;
+    template <bool use_adaptive_directions> accel inline void set_column(Model& model) const;
     template <bool use_adaptive_directions>
     accel inline Real get_column(const Model& model, const Size o, const Size r) const;
 };

--- a/src/solver/solver.tpp
+++ b/src/solver/solver.tpp
@@ -91,7 +91,7 @@ accel inline Real Solver ::get_dshift_max(const Model& model, const Size o) {
     return dshift_max;
 }
 
-template <Frame frame, bool use_adaptive_directions> 
+template <Frame frame, bool use_adaptive_directions>
 inline void Solver ::get_ray_lengths(Model& model) {
     for (Size rr = 0; rr < model.parameters->hnrays(); rr++) {
 
@@ -100,8 +100,9 @@ inline void Solver ::get_ray_lengths(Model& model) {
 
             const Real dshift_max = get_dshift_max(model, o);
 
-            model.geometry.lengths(rr, o) = model.geometry.get_ray_length<frame, use_adaptive_directions>(o, rr, dshift_max)
-                                          + model.geometry.get_ray_length<frame, use_adaptive_directions>(o, ar, dshift_max);
+            model.geometry.lengths(rr, o) =
+                model.geometry.get_ray_length<frame, use_adaptive_directions>(o, rr, dshift_max)
+                + model.geometry.get_ray_length<frame, use_adaptive_directions>(o, ar, dshift_max);
         })
 
         pc::accelerator::synchronize();
@@ -110,7 +111,8 @@ inline void Solver ::get_ray_lengths(Model& model) {
     model.geometry.lengths.copy_ptr_to_vec();
 }
 
-template <Frame frame, bool use_adaptive_directions> inline Size Solver ::get_ray_lengths_max(Model& model) {
+template <Frame frame, bool use_adaptive_directions>
+inline Size Solver ::get_ray_lengths_max(Model& model) {
     get_ray_lengths<frame, use_adaptive_directions>(model);
 
     Geometry& geo = model.geometry;
@@ -260,11 +262,12 @@ inline void Solver ::solve_feautrier_order_2_uv(Model& model) {
             nr_()[centre]    = o;
             shift_()[centre] = 1.0;
 
-            first_() =
-                trace_ray<CoMoving, use_adaptive_directions>(model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1)
-                + 1;
-            last_() =
-                trace_ray<CoMoving, use_adaptive_directions>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre) - 1;
+            first_() = trace_ray<CoMoving, use_adaptive_directions>(
+                           model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1)
+                     + 1;
+            last_() = trace_ray<CoMoving, use_adaptive_directions>(
+                          model.geometry, o, ar, dshift_max, +1, centre + 1, centre)
+                    - 1;
             n_tot_() = (last_() + 1) - first_();
 
             if (n_tot_() > 1) {
@@ -312,9 +315,11 @@ inline void Solver ::solve_feautrier_order_2_sparse(Model& model) {
 
         for (LineProducingSpecies& lspec : model.lines.lineProducingSpecies) {
             threaded_for(o, model.parameters->npoints(), {
-                const Vector3D nn = model.geometry.rays.get_direction<use_adaptive_directions>(o, rr);
-                const Size ar     = model.geometry.rays.get_antipod_index(rr);
-                const Real wt     = model.geometry.rays.get_weight<use_adaptive_directions>(o, rr) * two;
+                const Vector3D nn =
+                    model.geometry.rays.get_direction<use_adaptive_directions>(o, rr);
+                const Size ar = model.geometry.rays.get_antipod_index(rr);
+                const Real wt =
+                    model.geometry.rays.get_weight<use_adaptive_directions>(o, rr) * two;
 
                 const Real dshift_max = get_dshift_max(model, o);
 
@@ -324,9 +329,9 @@ inline void Solver ::solve_feautrier_order_2_sparse(Model& model) {
                 first_() = trace_ray<CoMoving, use_adaptive_directions>(
                                model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1)
                          + 1;
-                last_() =
-                    trace_ray<CoMoving, use_adaptive_directions>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre)
-                    - 1;
+                last_() = trace_ray<CoMoving, use_adaptive_directions>(
+                              model.geometry, o, ar, dshift_max, +1, centre + 1, centre)
+                        - 1;
                 n_tot_() = (last_() + 1) - first_();
 
                 if (n_tot_() > 1) {
@@ -337,7 +342,8 @@ inline void Solver ::solve_feautrier_order_2_sparse(Model& model) {
 
                             lspec.J(o, k) += lspec.quadrature.weights[z] * wt * Su_()[centre];
 
-                            update_Lambda<approx, use_adaptive_directions>(model, rr, lspec.nr_line[o][k][z]);
+                            update_Lambda<approx, use_adaptive_directions>(
+                                model, rr, lspec.nr_line[o][k][z]);
                         }
                     }
                 } else {
@@ -386,9 +392,10 @@ inline void Solver ::solve_feautrier_order_2_anis(Model& model) {
 
         for (LineProducingSpecies& lspec : model.lines.lineProducingSpecies) {
             threaded_for(o, model.parameters->npoints(), {
-                const Size ar     = model.geometry.rays.get_antipod_index(rr);
-                const Real wt     = model.geometry.rays.get_weight<use_adaptive_directions>(o, rr);
-                const Vector3D nn = model.geometry.rays.get_direction<use_adaptive_directions>(o, rr);
+                const Size ar = model.geometry.rays.get_antipod_index(rr);
+                const Real wt = model.geometry.rays.get_weight<use_adaptive_directions>(o, rr);
+                const Vector3D nn =
+                    model.geometry.rays.get_direction<use_adaptive_directions>(o, rr);
 
                 const Real wt_0    = inv_sqrt2 * (three * nn.z() * nn.z() - one);
                 const Real wt_1_Re = -sqrt3 * nn.x() * nn.z();
@@ -404,9 +411,9 @@ inline void Solver ::solve_feautrier_order_2_anis(Model& model) {
                 first_() = trace_ray<CoMoving, use_adaptive_directions>(
                                model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1)
                          + 1;
-                last_() =
-                    trace_ray<CoMoving, use_adaptive_directions>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre)
-                    - 1;
+                last_() = trace_ray<CoMoving, use_adaptive_directions>(
+                              model.geometry, o, ar, dshift_max, +1, centre + 1, centre)
+                        - 1;
                 n_tot_() = (last_() + 1) - first_();
 
                 if (n_tot_() > 1) {
@@ -481,9 +488,9 @@ inline void Solver ::solve_feautrier_order_2(Model& model) {
                 first_() = trace_ray<CoMoving, use_adaptive_directions>(
                                model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1)
                          + 1;
-                last_() =
-                    trace_ray<CoMoving, use_adaptive_directions>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre)
-                    - 1;
+                last_() = trace_ray<CoMoving, use_adaptive_directions>(
+                              model.geometry, o, ar, dshift_max, +1, centre + 1, centre)
+                        - 1;
                 n_tot_() = (last_() + 1) - first_();
 
                 if (n_tot_() > 1) {
@@ -492,7 +499,8 @@ inline void Solver ::solve_feautrier_order_2(Model& model) {
 
                         model.radiation.u(rr_loc, o, f) = Su_()[centre];
                         model.radiation.J(o, f) +=
-                            Su_()[centre] * two * model.geometry.rays.get_weight<use_adaptive_directions>(o, rr);
+                            Su_()[centre] * two
+                            * model.geometry.rays.get_weight<use_adaptive_directions>(o, rr);
 
                         update_Lambda<approx, use_adaptive_directions>(model, rr, f);
                     }
@@ -500,8 +508,9 @@ inline void Solver ::solve_feautrier_order_2(Model& model) {
                     for (Size f = 0; f < model.parameters->nfreqs(); f++) {
                         model.radiation.u(rr_loc, o, f) =
                             boundary_intensity(model, o, model.radiation.frequencies.nu(o, f));
-                        model.radiation.J(o, f) += two * model.geometry.rays.get_weight<use_adaptive_directions>(o, rr)
-                                                 * model.radiation.u(rr_loc, o, f);
+                        model.radiation.J(o, f) +=
+                            two * model.geometry.rays.get_weight<use_adaptive_directions>(o, rr)
+                            * model.radiation.u(rr_loc, o, f);
                     }
                 }
             })
@@ -538,8 +547,10 @@ inline void Solver ::image_feautrier_order_2(Model& model, const Size rr) {
         ;
 
         first_() =
-            trace_ray<Rest, false>(model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1) + 1;
-        last_()  = trace_ray<Rest, false>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre) - 1;
+            trace_ray<Rest, false>(model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1)
+            + 1;
+        last_() =
+            trace_ray<Rest, false>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre) - 1;
         n_tot_() = (last_() + 1) - first_();
 
         if (n_tot_() > 1) {
@@ -629,8 +640,9 @@ inline void Solver ::image_feautrier_order_2_for_point(Model& model, const Size 
     nr_()[centre]    = o;
     shift_()[centre] = model.geometry.get_shift<Rest, false>(o, rr, o, 0.0);
 
-    first_() = trace_ray<Rest, false>(model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1) + 1;
-    last_()  = trace_ray<Rest, false>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre) - 1;
+    first_() =
+        trace_ray<Rest, false>(model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1) + 1;
+    last_() = trace_ray<Rest, false>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre) - 1;
     n_tot_() = (last_() + 1) - first_();
 
     model.S_ray.resize(n_tot_(), model.parameters->nfreqs());
@@ -658,8 +670,10 @@ inline void Solver ::image_optical_depth(Model& model, const Size rr) {
         ;
 
         first_() =
-            trace_ray<Rest, false>(model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1) + 1;
-        last_()  = trace_ray<Rest, false>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre) - 1;
+            trace_ray<Rest, false>(model.geometry, o, rr, dshift_max, -1, centre - 1, centre - 1)
+            + 1;
+        last_() =
+            trace_ray<Rest, false>(model.geometry, o, ar, dshift_max, +1, centre + 1, centre) - 1;
         n_tot_() = (last_() + 1) - first_();
 
         if (n_tot_() > 1) {
@@ -1465,7 +1479,8 @@ accel inline void Solver ::update_Lambda(Model& model, const Size rr, const Size
         Matrix<Real>& L_lower = L_lower_();
         // Vector<Real  >& inverse_chi = inverse_chi_();
 
-        const Real w_ang = two * model.geometry.rays.get_weight<use_adaptive_directions>(nr[centre], rr);
+        const Real w_ang =
+            two * model.geometry.rays.get_weight<use_adaptive_directions>(nr[centre], rr);
 
         const Size l = freqs.corresponding_l_for_spec[f]; // index of species
         const Size k = freqs.corresponding_k_for_tran[f]; // index of transition
@@ -2520,8 +2535,7 @@ accel inline void Solver ::set_boundary_condition(Model& model) const {
     }
 }
 
-template <bool use_adaptive_directions>
-inline void Solver ::set_column(Model& model) const {
+template <bool use_adaptive_directions> inline void Solver ::set_column(Model& model) const {
     model.column.resize(model.parameters->nrays(), model.parameters->npoints());
 
     for (Size rr = 0; rr < model.parameters->hnrays(); rr++) {


### PR DESCRIPTION
Implements adaptive way of choosing ray directions for the normal solvers.
This includes python scripts to find the correct ray directions for each position and the C++ implementation of using these directions (mainly some refactoring work to allow to different directions per ray index)
Still TODO: 
- Add documentation on the usage of this feature
- Create a simple test benchmark to include this in the CI pipeline.

Note: this part will already be merged now, as I need to implement a similar feature in the comoving-approx branch.