### PR TITLE
271 add interpolation in case of significant source function variation

### DIFF
--- a/docs/src/4_extra_options/NLTE_in_low_density.rst
+++ b/docs/src/4_extra_options/NLTE_in_low_density.rst
@@ -4,28 +4,25 @@ NLTE in very low density regimes
 In low density regimes, the level populations might start to maser. 
 This means that the resulting line opacity (and optical depth) can become close to zero or even negative.
 Unfortunately, our solvers cannot handle a rapid change in source function (emissivity/opacity) too well, and might produce unphysical results.
+Therefore we both implement a minimum value for the line opacity and an interpolation scheme to avoid discontinuities in the line opacity.
 
 This is why we implement a workaround by setting the minimum allowed value for the line opacity (starting from version 0.7.0).
-This value is set to 1e-10 [W sr−1 m−3] by default, but can be changed by the user. Higher values can overestimate the impact of the less dense model regions on the intensity, while lower value can lead to numerical artifacts in the NLTE intensities (ring-like structures in the channel maps).
+This value is set to 1e-13 [W sr−1 m−3] by default, but can be changed by the user. Higher values can overestimate the impact of the less dense model regions on the intensity. Lower values can impact the number of interpolation points required for the computations (see below).
 
 .. code-block:: python
 
-    parameters.min_line_opacity = 1e-10#default
+    parameters.min_line_opacity = 1e-13#default
 
-In versions 0.5.3 until 0.6.0, the code implemented another workaround to avoid this situation by resetting specific levels at specific places to LTE.
-This might work in some cases (with the caveat of some artifacts being produced in the resulting spectrum), 
-but might as well produce new artifacts in when doing NLTE line radiative transfer in extremely low density regions. 
+In versions 0.6.0 until 0.9.0, the value was set to 1e-10 [W sr−1 m−3] by default, and the interpolation procedure was not yet implemented.
 
-To restore that behavior (without the new workaround), one can call
+----------------------------------------------------------------------------------------------------------------------------
 
-.. code-block:: python
-
-    parameters.population_inversion_fraction = 1.01#previous default
-    parameters.min_line_opacity = -1
-
-Finally, to restore the behavior of the code before version 0.5.3 (not recommended when using NLTE), one can call
+In NLTE line radiative transfer, the line opacity can change orders of magnitude between successive positions, leading to numerical artefacts.
+We implement an interpolation scheme to avoid these discontinuities in the line opacity.
+To regulate the number of interpolation points, the user can set the following parameter:
 
 .. code-block:: python
 
-    parameters.population_inversion_fraction = -1
-    parameters.min_line_opacity = -1
+    parameters.max_interpolation_diff = 1.4#default
+
+This parameter ensures that the (normalized) line opacities at max differ a factor *max_interpolation_diff* between two successive points.

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -290,6 +290,10 @@ PYBIND11_MODULE(core, module) {
             "Minimum opacity that will be assumed in the solver.")
         .def_readwrite("min_line_opacity", &Parameters::min_line_opacity,
             "Minimum line opacity that will be assumed in the solver.")
+        .def_readwrite("min_line_emissivity", &Parameters::min_line_emissivity,
+            "Minimum line emissivity that will be assumed in the solver.")
+        .def_readwrite("max_interpolation_diff", &Parameters::max_interpolation_diff,
+            "Maximum relative difference between successive line source functions.")
         .def_readwrite("min_dtau", &Parameters::min_dtau,
             "Minimum optical depth increment that will be assumed in the solver.")
         .def_readwrite("population_inversion_fraction", &Parameters::population_inversion_fraction,

--- a/src/bindings/pybindings.cpp
+++ b/src/bindings/pybindings.cpp
@@ -372,9 +372,9 @@ PYBIND11_MODULE(core, module) {
         .def_readonly("points", &Geometry::points, "Points object.")
         .def_readonly("rays", &Geometry::rays, "Rays object.")
         .def_readonly("boundary", &Geometry::boundary, "Boundary object")
-        .def_readonly("lengths", &Geometry::lengths,
-            "Array containing the lengths of the rays for each "
-            "direction and point.")
+        // .def_readonly("lengths", &Geometry::lengths,
+        //     "Array containing the lengths of the rays for each "
+        //     "direction and point.")
         // io
         .def("read", &Geometry::read, "Read object from file.")
         .def("write", &Geometry::write, "Write object to file.");

--- a/src/model/geometry/geometry.cpp
+++ b/src/model/geometry/geometry.cpp
@@ -5,7 +5,7 @@ void Geometry ::read(const Io& io) {
     rays.read(io);
     boundary.read(io);
 
-    lengths.resize(parameters->hnrays(), parameters->npoints());
+    // lengths.resize(parameters->hnrays(), parameters->npoints());
 }
 
 void Geometry ::write(const Io& io) const {

--- a/src/model/geometry/geometry.hpp
+++ b/src/model/geometry/geometry.hpp
@@ -30,8 +30,8 @@ struct Geometry {
     Rays rays;         ///< data structure containing ray (direction) data
     Boundary boundary; ///< data structure containing boundary data
 
-    Matrix<Size> lengths;
-    Size lengths_max;
+    // Matrix<Size> lengths;
+    // Size lengths_max;
 
     Geometry(std::shared_ptr<Parameters> params) :
         parameters(params), points(params), rays(params), boundary(params){};
@@ -83,11 +83,11 @@ struct Geometry {
         const Vector3D& origin_velocity, const Vector3D& raydir, const Size crt,
         const double Z) const;
 
-    accel inline Size get_n_interpl(
-        const double shift_crt, const double shift_nxt, const double dshift_max) const;
+    // accel inline Size get_n_interpl(
+    //     const double shift_crt, const double shift_nxt, const double dshift_max) const;
 
-    template <Frame frame, bool use_adaptive_directions>
-    accel inline Size get_ray_length(const Size o, const Size r, const double dshift_max) const;
+    // template <Frame frame, bool use_adaptive_directions>
+    // accel inline Size get_ray_length(const Size o, const Size r, const double dshift_max) const;
 
     inline bool valid_point(const Size p) const;
     inline bool not_on_boundary(const Size p) const;

--- a/src/model/geometry/geometry.hpp
+++ b/src/model/geometry/geometry.hpp
@@ -30,9 +30,6 @@ struct Geometry {
     Rays rays;         ///< data structure containing ray (direction) data
     Boundary boundary; ///< data structure containing boundary data
 
-    // Matrix<Size> lengths;
-    // Size lengths_max;
-
     Geometry(std::shared_ptr<Parameters> params) :
         parameters(params), points(params), rays(params), boundary(params){};
 
@@ -82,12 +79,6 @@ struct Geometry {
     accel inline double get_shift_spherical_symmetry(const Vector3D& origin,
         const Vector3D& origin_velocity, const Vector3D& raydir, const Size crt,
         const double Z) const;
-
-    // accel inline Size get_n_interpl(
-    //     const double shift_crt, const double shift_nxt, const double dshift_max) const;
-
-    // template <Frame frame, bool use_adaptive_directions>
-    // accel inline Size get_ray_length(const Size o, const Size r, const double dshift_max) const;
 
     inline bool valid_point(const Size p) const;
     inline bool not_on_boundary(const Size p) const;

--- a/src/model/geometry/geometry.tpp
+++ b/src/model/geometry/geometry.tpp
@@ -220,53 +220,6 @@ inline double Geometry ::get_shift_general_geometry<Rest>(
     return 1.0 + points.velocity[crt].dot(raydir);
 }
 
-// accel inline Size Geometry ::get_n_interpl(
-//     const double shift_crt, const double shift_nxt, const double dshift_max) const {
-//     const double dshift_abs = fabs(shift_nxt - shift_crt);
-
-//     if (dshift_abs > dshift_max) {
-//         return dshift_abs / dshift_max + 1;
-//     } else {
-//         return 1;
-//     }
-// }
-
-// template <Frame frame, bool use_adaptive_directions>
-// accel inline Size Geometry ::get_ray_length(
-//     const Size o, const Size r, const double dshift_max) const {
-//     Size l    = 0;   // ray length
-//     double Z  = 0.0; // distance from origin (o)
-//     double dZ = 0.0; // last increment in Z
-
-//     Size nxt = get_next<use_adaptive_directions>(o, r, o, Z, dZ);
-
-//     if (valid_point(nxt)) {
-//         Size crt         = o;
-//         double shift_crt = get_shift<frame, use_adaptive_directions>(o, r, crt, 0.0);
-//         double shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
-
-//         l += 1; // no interpolation means only a single point added to the ray each
-//                 // time
-
-//         while (not_on_boundary(nxt)) {
-//             crt       = nxt;
-//             shift_crt = shift_nxt;
-
-//             nxt       = get_next<use_adaptive_directions>(o, r, nxt, Z, dZ);
-//             shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
-
-//             l += 1; // no interpolation means only a single point added to the ray
-//                     // each time
-
-//             if (!valid_point(nxt)) {
-//                 printf("ERROR: no valid neighbor o=%u, r=%u, crt=%u\n", o, r, crt);
-//             }
-//         }
-//     }
-
-//     return l;
-// }
-
 ///  Check whether a point index is valid
 ///    @param[in] p : point index
 ///    @returns true if p is a valid index

--- a/src/model/geometry/geometry.tpp
+++ b/src/model/geometry/geometry.tpp
@@ -220,52 +220,52 @@ inline double Geometry ::get_shift_general_geometry<Rest>(
     return 1.0 + points.velocity[crt].dot(raydir);
 }
 
-accel inline Size Geometry ::get_n_interpl(
-    const double shift_crt, const double shift_nxt, const double dshift_max) const {
-    const double dshift_abs = fabs(shift_nxt - shift_crt);
+// accel inline Size Geometry ::get_n_interpl(
+//     const double shift_crt, const double shift_nxt, const double dshift_max) const {
+//     const double dshift_abs = fabs(shift_nxt - shift_crt);
 
-    if (dshift_abs > dshift_max) {
-        return dshift_abs / dshift_max + 1;
-    } else {
-        return 1;
-    }
-}
+//     if (dshift_abs > dshift_max) {
+//         return dshift_abs / dshift_max + 1;
+//     } else {
+//         return 1;
+//     }
+// }
 
-template <Frame frame, bool use_adaptive_directions>
-accel inline Size Geometry ::get_ray_length(
-    const Size o, const Size r, const double dshift_max) const {
-    Size l    = 0;   // ray length
-    double Z  = 0.0; // distance from origin (o)
-    double dZ = 0.0; // last increment in Z
+// template <Frame frame, bool use_adaptive_directions>
+// accel inline Size Geometry ::get_ray_length(
+//     const Size o, const Size r, const double dshift_max) const {
+//     Size l    = 0;   // ray length
+//     double Z  = 0.0; // distance from origin (o)
+//     double dZ = 0.0; // last increment in Z
 
-    Size nxt = get_next<use_adaptive_directions>(o, r, o, Z, dZ);
+//     Size nxt = get_next<use_adaptive_directions>(o, r, o, Z, dZ);
 
-    if (valid_point(nxt)) {
-        Size crt         = o;
-        double shift_crt = get_shift<frame, use_adaptive_directions>(o, r, crt, 0.0);
-        double shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
+//     if (valid_point(nxt)) {
+//         Size crt         = o;
+//         double shift_crt = get_shift<frame, use_adaptive_directions>(o, r, crt, 0.0);
+//         double shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
 
-        l += 1; // no interpolation means only a single point added to the ray each
-                // time
+//         l += 1; // no interpolation means only a single point added to the ray each
+//                 // time
 
-        while (not_on_boundary(nxt)) {
-            crt       = nxt;
-            shift_crt = shift_nxt;
+//         while (not_on_boundary(nxt)) {
+//             crt       = nxt;
+//             shift_crt = shift_nxt;
 
-            nxt       = get_next<use_adaptive_directions>(o, r, nxt, Z, dZ);
-            shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
+//             nxt       = get_next<use_adaptive_directions>(o, r, nxt, Z, dZ);
+//             shift_nxt = get_shift<frame, use_adaptive_directions>(o, r, nxt, Z);
 
-            l += 1; // no interpolation means only a single point added to the ray
-                    // each time
+//             l += 1; // no interpolation means only a single point added to the ray
+//                     // each time
 
-            if (!valid_point(nxt)) {
-                printf("ERROR: no valid neighbor o=%u, r=%u, crt=%u\n", o, r, crt);
-            }
-        }
-    }
+//             if (!valid_point(nxt)) {
+//                 printf("ERROR: no valid neighbor o=%u, r=%u, crt=%u\n", o, r, crt);
+//             }
+//         }
+//     }
 
-    return l;
-}
+//     return l;
+// }
 
 ///  Check whether a point index is valid
 ///    @param[in] p : point index

--- a/src/model/lines/lineProducingSpecies/lineProducingSpecies.tpp
+++ b/src/model/lines/lineProducingSpecies/lineProducingSpecies.tpp
@@ -24,7 +24,8 @@ inline Real LineProducingSpecies ::get_emissivity(const Size p, const Size k) co
     const Size i    = index(p, linedata.irad[k]);
     const Real freq = linedata.frequency[k];
 
-    return freq * HH_OVER_FOUR_PI * linedata.A[k] * population(i);
+    return std::max(
+        freq * HH_OVER_FOUR_PI * linedata.A[k] * population(i), parameters->min_line_emissivity);
 }
 
 ///  Getter for the line opacity

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -1153,8 +1153,8 @@ int Model ::set_column() {
     return (0);
 }
 
-// /  Setter for the maximum allowed shift value determined by the smallest line
-// /////////////////////////////////////////////////////////////////////////////
+///  Setter for the maximum allowed shift value determined by the smallest line
+///////////////////////////////////////////////////////////////////////////////
 int Model ::set_dshift_max() {
     // Allocate memory
     dshift_max.resize(parameters->npoints());

--- a/src/model/model.hpp
+++ b/src/model/model.hpp
@@ -100,7 +100,9 @@ struct Model {
 
     Matrix<Real> boundary_condition;
 
-    Vector<Real> dshift_max;
+    Vector<Real> dshift_max; // maximum allowed value of the Doppler shift in each point, before
+                             // applying either an analytic approach for the optical depth or adding
+                             // extra interpolation
 
     int set_dshift_max();
 

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -79,6 +79,7 @@ struct Parameters {
     Real min_opacity                 = 1.0e-26;
     long double min_line_opacity     = 1.0e-10;
     Real min_dtau                    = 1.0e-15;
+    Real max_source_diff = 1.4; //max relative differences between successive line source functions
     Real population_inversion_fraction =
         -1.0; // previously 1.01; // threshold factor for population inversion required
               //  for LTE to be used; set this higher than 1

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -80,7 +80,8 @@ struct Parameters {
     long double min_line_opacity     = 1.0e-10;
     long double min_line_emissivity  = 1.0e-100;
     Real min_dtau                    = 1.0e-15;
-    Real max_source_diff = 1.4; // max relative differences between successive line source functions
+    Real max_interpolation_diff =
+        1.4; // max relative differences between successive line source functions
     Real population_inversion_fraction =
         -1.0; // previously 1.01; // threshold factor for population inversion required
               //  for LTE to be used; set this higher than 1

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -78,7 +78,7 @@ struct Parameters {
     Real pop_prec                    = 1.0e-6;
     Real min_opacity                 = 1.0e-26;
     long double min_line_opacity     = 1.0e-13;
-    long double min_line_emissivity  = 1.0e-100;
+    long double min_line_emissivity  = 1.0e-50;
     Real min_dtau                    = 1.0e-15;
     Real max_interpolation_diff =
         1.4; // max relative differences between successive line source functions

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -77,7 +77,7 @@ struct Parameters {
     Real min_rel_pop_for_convergence = 1.0e-10;
     Real pop_prec                    = 1.0e-6;
     Real min_opacity                 = 1.0e-26;
-    long double min_line_opacity     = 1.0e-10;
+    long double min_line_opacity     = 1.0e-13;
     long double min_line_emissivity  = 1.0e-100;
     Real min_dtau                    = 1.0e-15;
     Real max_interpolation_diff =

--- a/src/model/parameters/parameters.hpp
+++ b/src/model/parameters/parameters.hpp
@@ -78,8 +78,9 @@ struct Parameters {
     Real pop_prec                    = 1.0e-6;
     Real min_opacity                 = 1.0e-26;
     long double min_line_opacity     = 1.0e-10;
+    long double min_line_emissivity  = 1.0e-100;
     Real min_dtau                    = 1.0e-15;
-    Real max_source_diff = 1.4; //max relative differences between successive line source functions
+    Real max_source_diff = 1.4; // max relative differences between successive line source functions
     Real population_inversion_fraction =
         -1.0; // previously 1.01; // threshold factor for population inversion required
               //  for LTE to be used; set this higher than 1

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -75,8 +75,8 @@ struct Solver {
 
     Size n_off_diag;
 
-    InterpHelper interp_helper;
-    // Matrix<Size> ray_lengths;
+    InterpHelper interp_helper; // FIXME: replace with std::optional<InterpHelper> in the future;
+                                // then remove the default constructor definition
 
     template <Frame frame, bool use_adaptive_directions> void setup(Model& model);
 
@@ -85,13 +85,8 @@ struct Solver {
 
     void setup(const Size l, const Size w, const Size n_o_d);
 
-    // accel inline Real get_dshift_max(const Model& model, const Size o);
-
     template <Frame frame, bool use_adaptive_directions>
     inline Size get_ray_length(Model& model, const Size o, const Size r) const;
-
-    // template <Frame frame, bool use_adaptive_directions> inline void get_ray_lengths(Model&
-    // model);
 
     template <Frame frame, bool use_adaptive_directions>
     inline Size get_ray_lengths_max(Model& model);

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -160,15 +160,12 @@ struct Solver {
 
     template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void update_Lambda(Model& model, const Size rr, const Size f);
-    // accel inline void solve_shortchar_order_0_ray_forward (
-    //           Model& model,
-    //           const Size   o,
-    //           const Size   r);
-    // accel inline void solve_shortchar_order_0_ray_backward
-    // (
-    //           Model& model,
-    //           const Size   o,
-    //           const Size   r);
+    template <ApproximationType approx, bool use_adaptive_directions>
+    accel inline Real solve_shortchar_order_0_ray_forward(
+        Model& model, const Size o, const Size r, const Size f);
+    template <ApproximationType approx, bool use_adaptive_directions>
+    accel inline Real solve_shortchar_order_0_ray_backward(
+        Model& model, const Size o, const Size r, const Size f);
 
     // Solvers for images
     /////////////////////
@@ -217,8 +214,8 @@ struct Solver {
 
     template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void solve_shortchar_order_0(Model& model);
-    template <ApproximationType approx, bool use_adaptive_directions>
-    accel inline void solve_shortchar_order_0(Model& model, const Size o, const Size r);
+    // template <ApproximationType approx, bool use_adaptive_directions>
+    // accel inline void solve_shortchar_order_0(Model& model, const Size o, const Size r);
 
     template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void solve_feautrier_order_2_uv(Model& model);

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "model/model.hpp"
-#include "tools/types.hpp"
 #include "solver/solver_interp_helper.hpp"
+#include "tools/types.hpp"
 
 ///  Approximation used in the solver
 /////////////////////////////////////
@@ -19,8 +19,11 @@ struct Solver {
 
     pc::multi_threading::ThreadPrivate<Vector<double>> dZ_; ///< distance increments along the ray
     pc::multi_threading::ThreadPrivate<Vector<Size>> nr_; ///< corresponding point number on the ray
-    pc::multi_threading::ThreadPrivate<Vector<Size>> nr_interp_; ///< corresponding point number for interpolation on the ray
-    pc::multi_threading::ThreadPrivate<Vector<double>> interp_factor_; ///< Distance along interpolation between nr_ and nr_interp_ (contains values between 0 and 1)
+    pc::multi_threading::ThreadPrivate<Vector<Size>>
+        nr_interp_; ///< corresponding point number for interpolation on the ray
+    pc::multi_threading::ThreadPrivate<Vector<double>>
+        interp_factor_; ///< Distance along interpolation between nr_ and nr_interp_ (contains
+                        ///< values between 0 and 1)
     pc::multi_threading::ThreadPrivate<Vector<double>> shift_; ///< Doppler shift along the ray
 
     pc::multi_threading::ThreadPrivate<Vector<Real>> eta_c_;
@@ -72,7 +75,7 @@ struct Solver {
 
     Size n_off_diag;
 
-    InterpHelper interp_helper;
+    std::optional<InterpHelper> interp_helper;
     Matrix<Size> ray_lengths;
 
     template <Frame frame, bool use_adaptive_directions> void setup(Model& model);
@@ -83,7 +86,6 @@ struct Solver {
     void setup(const Size l, const Size w, const Size n_o_d);
 
     // accel inline Real get_dshift_max(const Model& model, const Size o);
-
 
     template <Frame frame, bool use_adaptive_directions>
     inline Size get_ray_length(Model& model, const Size o, const Size r) const;
@@ -96,23 +98,23 @@ struct Solver {
     // template <Frame frame>
     inline Size get_ray_lengths_max_new_imager(Model& model, Image& image, const Vector3D& ray_dir);
 
-    accel inline Size get_ray_length_new_imager(const Geometry& geometry, const Vector3D& origin,
-        const Size start_bdy, const Vector3D& raydir);
+    accel inline Size get_ray_length_new_imager(
+        const Model& model, const Vector3D& origin, const Size start_bdy, const Vector3D& raydir);
 
     template <Frame frame, bool use_adaptive_directions>
-    accel inline Size trace_ray(const Geometry& geometry, const Size o, const Size r,
-        const double dshift_max, const int increment, Size id1, Size id2);
+    accel inline Size trace_ray(
+        const Model& model, const Size o, const Size r, const int increment, Size id1, Size id2);
 
     accel inline Size trace_ray_imaging_get_start(const Geometry& geometry, const Vector3D& origin,
         const Size start_bdy, const Vector3D& raydir, Real& Z);
 
     template <Frame frame>
-    accel inline Size trace_ray_imaging(const Geometry& geometry, const Vector3D& origin,
-        const Size start_bdy, const Vector3D& raydir, const double dshift_max, const int increment,
-        Real& Z, Size id1, Size id2);
+    accel inline Size trace_ray_imaging(const Model& model, const Vector3D& origin,
+        const Size start_bdy, const Vector3D& raydir, const int increment, Real& Z, Size id1,
+        Size id2);
 
-    accel inline void set_data(const Size crt, const Size nxt, const double shift_crt,
-        const double shift_nxt, const double dZ_loc, const double dshift_max, const int increment,
+    accel inline void set_data(const Model& model, const Size crt, const Size nxt,
+        const double shift_crt, const double shift_nxt, const double dZ_loc, const int increment,
         Size& id1, Size& id2);
 
     accel inline Real gaussian(const Real width, const Real diff) const;
@@ -125,21 +127,25 @@ struct Solver {
         const Real freq, Real& eta, Real& chi) const;
 
     template <ApproximationType approx>
-    accel inline void get_eta_and_chi_interpolated(const Model& model, const Size p1, const Size p2, const Real factor, const Size l,
-        const Real freq, Real& eta, Real& chi) const;
+    accel inline void get_eta_and_chi_interpolated(const Model& model, const Size p1, const Size p2,
+        const Real factor, const Size l, const Real freq, Real& eta, Real& chi) const;
 
     template <ApproximationType approx>
     inline void compute_S_dtau_line_integrated(Model& model, Size currpoint, Size nextpoint,
-        Size lineidx, Real currfreq, Real nextfreq, Real dZ, Real& dtau, Real& Scurr, Real& Snext);
+        Size currpoint_interp_idx, Size nextpoint_interp_idx, Size lineidx, Real currfreq,
+        Real nextfreq, Real dZ, Real curr_interp, Real next_interp, Real& dtau, Real& Scurr,
+        Real& Snext);
 
-    inline Real compute_dtau_single_line(Model& model, Size curridx, Size nextidx, Size lineidx,
-        Real curr_freq, Real next_freq, Real dz);
+    inline Real compute_dtau_single_line(Model& model, Size curridx, Size nextidx,
+        Size currpoint_interp_idx, Size nextpoint_interp_idx, Size lineidx, Real curr_freq,
+        Real next_freq, Real curr_interp, Real next_interp, Real dz);
 
     template <ApproximationType approx>
-    accel inline void compute_source_dtau(Model& model, Size currpoint, Size nextpoint, Size line,
-        Real curr_freq, Real next_freq, double curr_shift, double next_shift, Real dZ,
-        bool& compute_curr_opacity, Real& dtaunext, Real& chicurr, Real& chinext, Real& Scurr,
-        Real& Snext);
+    accel inline void compute_source_dtau(Model& model, Size currpoint, Size nextpoint,
+        Size currpoint_interp_idx, Size nextpoint_interp_idx, Size line, Real curr_freq,
+        Real next_freq, double curr_shift, double next_shift, Real curr_interp, Real next_interp,
+        Real dZ, bool& compute_curr_opacity, Real& dtaunext, Real& chicurr, Real& chinext,
+        Real& Scurr, Real& Snext);
 
     template <ApproximationType approx, bool use_adaptive_directions>
     accel inline void update_Lambda(Model& model, const Size rr, const Size f);

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -75,8 +75,8 @@ struct Solver {
 
     Size n_off_diag;
 
-    std::optional<InterpHelper> interp_helper;
-    Matrix<Size> ray_lengths;
+    InterpHelper interp_helper;
+    // Matrix<Size> ray_lengths;
 
     template <Frame frame, bool use_adaptive_directions> void setup(Model& model);
 
@@ -90,7 +90,8 @@ struct Solver {
     template <Frame frame, bool use_adaptive_directions>
     inline Size get_ray_length(Model& model, const Size o, const Size r) const;
 
-    template <Frame frame, bool use_adaptive_directions> inline void get_ray_lengths(Model& model);
+    // template <Frame frame, bool use_adaptive_directions> inline void get_ray_lengths(Model&
+    // model);
 
     template <Frame frame, bool use_adaptive_directions>
     inline Size get_ray_lengths_max(Model& model);
@@ -104,6 +105,9 @@ struct Solver {
     template <Frame frame, bool use_adaptive_directions>
     accel inline Size trace_ray(
         const Model& model, const Size o, const Size r, const int increment, Size id1, Size id2);
+    template <Frame frame, bool use_adaptive_directions>
+    accel inline Size trace_ray_for_line(const Model& model, const Size l, const Size o,
+        const Size r, const int increment, Size id1, Size id2);
 
     accel inline Size trace_ray_imaging_get_start(const Geometry& geometry, const Vector3D& origin,
         const Size start_bdy, const Vector3D& raydir, Real& Z);
@@ -112,10 +116,17 @@ struct Solver {
     accel inline Size trace_ray_imaging(const Model& model, const Vector3D& origin,
         const Size start_bdy, const Vector3D& raydir, const int increment, Real& Z, Size id1,
         Size id2);
+    template <Frame frame>
+    accel inline Size trace_ray_imaging_for_line(const Model& model, const Size l,
+        const Vector3D& origin, const Size start_bdy, const Vector3D& raydir, const int increment,
+        Real& Z, Size id1, Size id2);
 
     accel inline void set_data(const Model& model, const Size crt, const Size nxt,
         const double shift_crt, const double shift_nxt, const double dZ_loc, const int increment,
         Size& id1, Size& id2);
+    accel inline void set_data_for_line(const Model& model, const Size l, const Size crt,
+        const Size nxt, const double shift_crt, const double shift_nxt, const double dZ_loc,
+        const int increment, Size& id1, Size& id2);
 
     accel inline Real gaussian(const Real width, const Real diff) const;
     accel inline Real planck(const Real temp, const Real freq) const;

--- a/src/solver/solver.hpp
+++ b/src/solver/solver.hpp
@@ -2,6 +2,7 @@
 
 #include "model/model.hpp"
 #include "tools/types.hpp"
+#include "solver/solver_interp_helper.hpp"
 
 ///  Approximation used in the solver
 /////////////////////////////////////
@@ -18,6 +19,8 @@ struct Solver {
 
     pc::multi_threading::ThreadPrivate<Vector<double>> dZ_; ///< distance increments along the ray
     pc::multi_threading::ThreadPrivate<Vector<Size>> nr_; ///< corresponding point number on the ray
+    pc::multi_threading::ThreadPrivate<Vector<Size>> nr_interp_; ///< corresponding point number for interpolation on the ray
+    pc::multi_threading::ThreadPrivate<Vector<double>> interp_factor_; ///< Distance along interpolation between nr_ and nr_interp_ (contains values between 0 and 1)
     pc::multi_threading::ThreadPrivate<Vector<double>> shift_; ///< Doppler shift along the ray
 
     pc::multi_threading::ThreadPrivate<Vector<Real>> eta_c_;
@@ -69,6 +72,9 @@ struct Solver {
 
     Size n_off_diag;
 
+    InterpHelper interp_helper;
+    Matrix<Size> ray_lengths;
+
     template <Frame frame, bool use_adaptive_directions> void setup(Model& model);
 
     // template <Frame frame>
@@ -76,7 +82,11 @@ struct Solver {
 
     void setup(const Size l, const Size w, const Size n_o_d);
 
-    accel inline Real get_dshift_max(const Model& model, const Size o);
+    // accel inline Real get_dshift_max(const Model& model, const Size o);
+
+
+    template <Frame frame, bool use_adaptive_directions>
+    inline Size get_ray_length(Model& model, const Size o, const Size r) const;
 
     template <Frame frame, bool use_adaptive_directions> inline void get_ray_lengths(Model& model);
 
@@ -112,6 +122,10 @@ struct Solver {
 
     template <ApproximationType approx>
     accel inline void get_eta_and_chi(const Model& model, const Size p, const Size l,
+        const Real freq, Real& eta, Real& chi) const;
+
+    template <ApproximationType approx>
+    accel inline void get_eta_and_chi_interpolated(const Model& model, const Size p1, const Size p2, const Real factor, const Size l,
         const Real freq, Real& eta, Real& chi) const;
 
     template <ApproximationType approx>

--- a/src/solver/solver.tpp
+++ b/src/solver/solver.tpp
@@ -1915,20 +1915,35 @@ inline void Solver ::compute_S_dtau_line_integrated<OneLine>(Model& model, Size 
     Size nextpoint, Size currpoint_interp_idx, Size nextpoint_interp_idx, Size lineidx,
     Real currfreq, Real nextfreq, Real curr_interp, Real next_interp, Real dZ, Real& dtau,
     Real& Scurr, Real& Snext) {
+    // FIXME: line idx is wrong
     dtau = compute_dtau_single_line(model, currpoint, nextpoint, currpoint_interp_idx,
         nextpoint_interp_idx, lineidx, currfreq, nextfreq, curr_interp, next_interp, dZ);
-    const Real curr_opacity = interp_helper.interpolate_log(model.lines.opacity(currpoint, lineidx),
-        model.lines.opacity(currpoint_interp_idx, lineidx), curr_interp);
-    const Real next_opacity = interp_helper.interpolate_log(model.lines.opacity(nextpoint, lineidx),
-        model.lines.opacity(nextpoint_interp_idx, lineidx), next_interp);
-    const Real curr_emissivity =
-        interp_helper.interpolate_log(model.lines.emissivity(currpoint, lineidx),
-            model.lines.emissivity(currpoint_interp_idx, lineidx), curr_interp);
-    const Real next_emissivity =
-        interp_helper.interpolate_log(model.lines.emissivity(nextpoint, lineidx),
-            model.lines.emissivity(nextpoint_interp_idx, lineidx), next_interp);
-    Scurr = curr_emissivity / curr_opacity;
-    Snext = next_emissivity / next_opacity;
+    // const Real curr_opacity = interp_helper.interpolate_log(model.lines.opacity(currpoint,
+    // lineidx),
+    //     model.lines.opacity(currpoint_interp_idx, lineidx), curr_interp);
+    // const Real next_opacity = interp_helper.interpolate_log(model.lines.opacity(nextpoint,
+    // lineidx),
+    //     model.lines.opacity(nextpoint_interp_idx, lineidx), next_interp);
+    // const Real curr_emissivity =
+    //     interp_helper.interpolate_log(model.lines.emissivity(currpoint, lineidx),
+    //         model.lines.emissivity(currpoint_interp_idx, lineidx), curr_interp);
+    // const Real next_emissivity =
+    //     interp_helper.interpolate_log(model.lines.emissivity(nextpoint, lineidx),
+    //         model.lines.emissivity(nextpoint_interp_idx, lineidx), next_interp);
+    // Scurr = curr_emissivity / curr_opacity;
+    // Snext = next_emissivity / next_opacity;
+
+    Real Scurr_p =
+        model.lines.emissivity(currpoint, lineidx) / model.lines.opacity(currpoint, lineidx);
+    Real Snext_p =
+        model.lines.emissivity(nextpoint, lineidx) / model.lines.opacity(nextpoint, lineidx);
+    Real Scurr_interp_p = model.lines.emissivity(currpoint_interp_idx, lineidx)
+                        / model.lines.opacity(currpoint_interp_idx, lineidx);
+    Real Snext_interp_p = model.lines.emissivity(nextpoint_interp_idx, lineidx)
+                        / model.lines.opacity(nextpoint_interp_idx, lineidx);
+
+    Scurr = interp_helper.interpolate_log(Scurr_p, Scurr_interp_p, curr_interp);
+    Snext = interp_helper.interpolate_log(Snext_p, Snext_interp_p, next_interp);
 }
 
 ///  Computer for the optical depth and source function when
@@ -1967,21 +1982,31 @@ inline void Solver ::compute_S_dtau_line_integrated<None>(Model& model, Size cur
     Real sum_dtau_times_Snext = 0.0;
     for (Size l = 0; l < model.parameters->nlines(); l++) {
         Real line_dtau = compute_dtau_single_line(model, currpoint, nextpoint, currpoint_interp_idx,
-            nextpoint_interp_idx, lineidx, currfreq, nextfreq, curr_interp, next_interp, dZ);
-        const Real curr_opacity =
-            interp_helper.interpolate_log(model.lines.opacity(currpoint, lineidx),
-                model.lines.opacity(currpoint_interp_idx, lineidx), curr_interp);
-        const Real next_opacity =
-            interp_helper.interpolate_log(model.lines.opacity(nextpoint, lineidx),
-                model.lines.opacity(nextpoint_interp_idx, lineidx), next_interp);
-        const Real curr_emissivity =
-            interp_helper.interpolate_log(model.lines.emissivity(currpoint, lineidx),
-                model.lines.emissivity(currpoint_interp_idx, lineidx), curr_interp);
-        const Real next_emissivity =
-            interp_helper.interpolate_log(model.lines.emissivity(nextpoint, lineidx),
-                model.lines.emissivity(nextpoint_interp_idx, lineidx), next_interp);
-        Real line_Scurr = curr_emissivity / curr_opacity;
-        Real line_Snext = next_emissivity / next_opacity;
+            nextpoint_interp_idx, l, currfreq, nextfreq, curr_interp, next_interp, dZ);
+        // const Real curr_opacity =
+        //     interp_helper.interpolate_log(model.lines.opacity(currpoint, lineidx),
+        //         model.lines.opacity(currpoint_interp_idx, lineidx), curr_interp);
+        // const Real next_opacity =
+        //     interp_helper.interpolate_log(model.lines.opacity(nextpoint, lineidx),
+        //         model.lines.opacity(nextpoint_interp_idx, lineidx), next_interp);
+        // const Real curr_emissivity =
+        //     interp_helper.interpolate_log(model.lines.emissivity(currpoint, lineidx),
+        //         model.lines.emissivity(currpoint_interp_idx, lineidx), curr_interp);
+        // const Real next_emissivity =
+        //     interp_helper.interpolate_log(model.lines.emissivity(nextpoint, lineidx),
+        //         model.lines.emissivity(nextpoint_interp_idx, lineidx), next_interp);
+        // Real line_Scurr = curr_emissivity / curr_opacity;
+        // Real line_Snext = next_emissivity / next_opacity;
+
+        Real Scurr_p = model.lines.emissivity(currpoint, l) / model.lines.opacity(currpoint, l);
+        Real Snext_p = model.lines.emissivity(nextpoint, l) / model.lines.opacity(nextpoint, l);
+        Real Scurr_interp_p = model.lines.emissivity(currpoint_interp_idx, l)
+                            / model.lines.opacity(currpoint_interp_idx, l);
+        Real Snext_interp_p = model.lines.emissivity(nextpoint_interp_idx, l)
+                            / model.lines.opacity(nextpoint_interp_idx, l);
+
+        Real line_Scurr = interp_helper.interpolate_log(Scurr_p, Scurr_interp_p, curr_interp);
+        Real line_Snext = interp_helper.interpolate_log(Snext_p, Snext_interp_p, next_interp);
 
         sum_dtau += line_dtau;
         sum_dtau_times_Scurr += line_dtau * line_Scurr;
@@ -2069,21 +2094,31 @@ inline void Solver ::compute_S_dtau_line_integrated<CloseLines>(Model& model, Si
         const Size l = model.lines.sorted_line_map[sort_l];
 
         Real line_dtau = compute_dtau_single_line(model, currpoint, nextpoint, currpoint_interp_idx,
-            nextpoint_interp_idx, lineidx, currfreq, nextfreq, curr_interp, next_interp, dZ);
-        const Real curr_opacity =
-            interp_helper.interpolate_log(model.lines.opacity(currpoint, lineidx),
-                model.lines.opacity(currpoint_interp_idx, lineidx), curr_interp);
-        const Real next_opacity =
-            interp_helper.interpolate_log(model.lines.opacity(nextpoint, lineidx),
-                model.lines.opacity(nextpoint_interp_idx, lineidx), next_interp);
-        const Real curr_emissivity =
-            interp_helper.interpolate_log(model.lines.emissivity(currpoint, lineidx),
-                model.lines.emissivity(currpoint_interp_idx, lineidx), curr_interp);
-        const Real next_emissivity =
-            interp_helper.interpolate_log(model.lines.emissivity(nextpoint, lineidx),
-                model.lines.emissivity(nextpoint_interp_idx, lineidx), next_interp);
-        Real line_Scurr = curr_emissivity / curr_opacity;
-        Real line_Snext = next_emissivity / next_opacity;
+            nextpoint_interp_idx, l, currfreq, nextfreq, curr_interp, next_interp, dZ);
+        // const Real curr_opacity =
+        //     interp_helper.interpolate_log(model.lines.opacity(currpoint, lineidx),
+        //         model.lines.opacity(currpoint_interp_idx, lineidx), curr_interp);
+        // const Real next_opacity =
+        //     interp_helper.interpolate_log(model.lines.opacity(nextpoint, lineidx),
+        //         model.lines.opacity(nextpoint_interp_idx, lineidx), next_interp);
+        // const Real curr_emissivity =
+        //     interp_helper.interpolate_log(model.lines.emissivity(currpoint, lineidx),
+        //         model.lines.emissivity(currpoint_interp_idx, lineidx), curr_interp);
+        // const Real next_emissivity =
+        //     interp_helper.interpolate_log(model.lines.emissivity(nextpoint, lineidx),
+        //         model.lines.emissivity(nextpoint_interp_idx, lineidx), next_interp);
+        // Real line_Scurr = curr_emissivity / curr_opacity;
+        // Real line_Snext = next_emissivity / next_opacity;
+
+        Real Scurr_p = model.lines.emissivity(currpoint, l) / model.lines.opacity(currpoint, l);
+        Real Snext_p = model.lines.emissivity(nextpoint, l) / model.lines.opacity(nextpoint, l);
+        Real Scurr_interp_p = model.lines.emissivity(currpoint_interp_idx, l)
+                            / model.lines.opacity(currpoint_interp_idx, l);
+        Real Snext_interp_p = model.lines.emissivity(nextpoint_interp_idx, l)
+                            / model.lines.opacity(nextpoint_interp_idx, l);
+
+        Real line_Scurr = interp_helper.interpolate_log(Scurr_p, Scurr_interp_p, curr_interp);
+        Real line_Snext = interp_helper.interpolate_log(Snext_p, Snext_interp_p, next_interp);
 
         sum_dtau += line_dtau;
         sum_dtau_times_Scurr += line_dtau * line_Scurr;
@@ -2396,6 +2431,8 @@ inline Real Solver ::compute_dtau_single_line(Model& model, Size curridx, Size n
     // optical depth formula) happens if we were not to use
     // this branch
     if (curr_freq == next_freq) {
+        std::cout << "Warning: Frequencies are equal, using default computation for optical depth"
+                  << std::endl;
         // doing the default computation instead (no shifting)
         const Real diff = curr_freq - model.lines.line[lineidx]; // curr_freq==next_freq,
                                                                  // so choice is arbitrary

--- a/src/solver/solver_interp_helper.hpp
+++ b/src/solver/solver_interp_helper.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include "model/model.hpp"
+#include "tools/types.hpp"
+
+//Contains a helper class for allowing interpolation when the variation in some quantity is too large.
+class InterpHelper {
+
+public:
+    Real max_source_diff;
+    // Model model;
+    std::vector<Real> line_sources;
+    ///  Constructor
+    ///    @param[in] dshift_max : maximum shift between two points
+    /////////////////////////////////////////////////
+    InterpHelper(Model& model) : max_source_diff(model.parameters->max_source_diff) {
+        // std::vector<Real> line_sources;
+        // model_ptr = std::make_shared(model);
+        line_sources.reserve(model.lines.emissivity.vec.size());
+        std::transform(model.lines.emissivity.vec.begin(), model.lines.emissivity.vec.end(), model.lines.opacity.vec.begin(), line_sources.begin(), [](Real x, Real y) { return x/y; });
+
+    }
+
+    inline Size get_n_interp(Model& model, const Size curr_idx, const Size next_idx) const;
+    inline std::vector<Real> get_subvector_sources(Model& model, const Size curr_idx) const;
+    inline Real interpolate_linear(const Real f_start, const Real f_end, const Real factor) const;
+    inline Real interpolate_log(const Real f_start, const Real f_end, const Real factor) const;
+
+    // ///  Get the number of points to interpolate between two points
+    // ///    @param[in] curr_idx : index of the current point
+    // ///    @param[in] next_idx : index of the next point
+    // ///    @returns number of points to interpolate
+    // /////////////////////////////////////////////////
+    // /// TODO: currently, this will result in probably too much interpolation, as the resulting grid is uniform for all lines/frequencies.
+    // inline Size get_n_interpl(const Size curr_idx, const Size next_idx) const {
+    //     std::vector<Real> curr_sources = get_subvector_sources(curr_idx);
+    //     std::vector<Real> next_sources = get_subvector_sources(next_idx);
+    //     // get relative difference between sources
+    //     std::vector<Real> sources_diff = next_sources / curr_sources;
+    //     // convert to ln, and take absolute value
+    //     std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(), [](Real x) { return fabs(log(x)); });
+    //     const Size source_diff_n_interp = std::ceil(*std::max_element(sources_diff.begin(), sources_diff.end())/std::log(max_source_diff));
+
+    //     if (source_diff_n_interp > 1) {
+    //         return source_diff_n_interp;
+    //     } else {
+    //         return 1;
+    //     }
+    // }
+
+    // inline std::vector<Real> get_subvector_sources(const Size curr_idx) const {
+    //     Size curr_line_start_idx = model.lines.get_index(curr_idx, 0);//assumes all data from any point lies next to eachother in the vector
+    //     Size curr_line_end_idx = model.lines.get_index(curr_idx + 1, 0);
+
+    //     return std::vector<Real>(self.line_sources.begin() + curr_line_start_idx, self.line_sources.begin() + curr_line_end_idx);
+    // }
+};
+
+#include "solver_interp_helper.tpp"

--- a/src/solver/solver_interp_helper.hpp
+++ b/src/solver/solver_interp_helper.hpp
@@ -8,19 +8,13 @@ class InterpHelper {
 
   public:
     Real max_source_diff;
-    // Model model;
     std::vector<Real> interpolation_criterion; // Note: contains the density normalized line opacity
     ///  Constructor
     ///    @param[in] dshift_max : maximum shift between two points
     /////////////////////////////////////////////////
     InterpHelper(Model& model) : max_source_diff(model.parameters->max_interpolation_diff) {
-        // std::vector<Real> line_sources;
-        // model_ptr = std::make_shared(model);
-        // line_sources.reserve(model.lines.emissivity.vec.size());
-        // std::transform(model.lines.emissivity.vec.begin(), model.lines.emissivity.vec.end(),
-        //     model.lines.opacity.vec.begin(), line_sources.begin(),
-        //     [&](Real x, Real y) { return x / y; });
-        // line_sources = model.lines.opacity.vec;
+        // current interpolation criterion based on the line opacity (normalized by the total
+        // population)
         interpolation_criterion.resize(model.lines.emissivity.vec.size());
         threaded_for(p, model.parameters->npoints(), {
             for (Size l = 0; l < model.parameters->nlspecs(); l++) {
@@ -36,13 +30,15 @@ class InterpHelper {
     }
 
     /// DO NOT USE THIS CONSTRUCTOR
+    // TODO: in solver.hpp/.tpp, replace the object with an std::optional<...> version.
     InterpHelper() : max_source_diff(-1){};
 
+    // NOTE: interpolation is done in log space, as linear space would take far too many points
     inline Size get_n_interp(const Model& model, const Size curr_idx, const Size next_idx) const;
     inline Size get_n_interp_for_line(
         const Model& model, const Size l, const Size curr_idx, const Size next_idx) const;
-    inline std::vector<Real> get_subvector_interpolation_criterion(
-        const Model& model, const Size curr_idx) const;
+
+    // Interpolation functions themselves
     inline Real interpolate_linear(const Real f_start, const Real f_end, const Real factor) const;
     inline Real interpolate_log(const Real f_start, const Real f_end, const Real factor) const;
 };

--- a/src/solver/solver_interp_helper.hpp
+++ b/src/solver/solver_interp_helper.hpp
@@ -2,10 +2,11 @@
 #include "model/model.hpp"
 #include "tools/types.hpp"
 
-//Contains a helper class for allowing interpolation when the variation in some quantity is too large.
+// Contains a helper class for allowing interpolation when the variation in some quantity is too
+// large.
 class InterpHelper {
 
-public:
+  public:
     Real max_source_diff;
     // Model model;
     std::vector<Real> line_sources;
@@ -16,12 +17,13 @@ public:
         // std::vector<Real> line_sources;
         // model_ptr = std::make_shared(model);
         line_sources.reserve(model.lines.emissivity.vec.size());
-        std::transform(model.lines.emissivity.vec.begin(), model.lines.emissivity.vec.end(), model.lines.opacity.vec.begin(), line_sources.begin(), [](Real x, Real y) { return x/y; });
-
+        std::transform(model.lines.emissivity.vec.begin(), model.lines.emissivity.vec.end(),
+            model.lines.opacity.vec.begin(), line_sources.begin(),
+            [&](Real x, Real y) { return x / (y + model.parameters->min_line_opacity); });
     }
 
-    inline Size get_n_interp(Model& model, const Size curr_idx, const Size next_idx) const;
-    inline std::vector<Real> get_subvector_sources(Model& model, const Size curr_idx) const;
+    inline Size get_n_interp(const Model& model, const Size curr_idx, const Size next_idx) const;
+    inline std::vector<Real> get_subvector_sources(const Model& model, const Size curr_idx) const;
     inline Real interpolate_linear(const Real f_start, const Real f_end, const Real factor) const;
     inline Real interpolate_log(const Real f_start, const Real f_end, const Real factor) const;
 
@@ -30,15 +32,18 @@ public:
     // ///    @param[in] next_idx : index of the next point
     // ///    @returns number of points to interpolate
     // /////////////////////////////////////////////////
-    // /// TODO: currently, this will result in probably too much interpolation, as the resulting grid is uniform for all lines/frequencies.
-    // inline Size get_n_interpl(const Size curr_idx, const Size next_idx) const {
+    // /// TODO: currently, this will result in probably too much interpolation, as the resulting
+    // grid is uniform for all lines/frequencies. inline Size get_n_interpl(const Size curr_idx,
+    // const Size next_idx) const {
     //     std::vector<Real> curr_sources = get_subvector_sources(curr_idx);
     //     std::vector<Real> next_sources = get_subvector_sources(next_idx);
     //     // get relative difference between sources
     //     std::vector<Real> sources_diff = next_sources / curr_sources;
     //     // convert to ln, and take absolute value
-    //     std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(), [](Real x) { return fabs(log(x)); });
-    //     const Size source_diff_n_interp = std::ceil(*std::max_element(sources_diff.begin(), sources_diff.end())/std::log(max_source_diff));
+    //     std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(), [](Real x)
+    //     { return fabs(log(x)); }); const Size source_diff_n_interp =
+    //     std::ceil(*std::max_element(sources_diff.begin(),
+    //     sources_diff.end())/std::log(max_source_diff));
 
     //     if (source_diff_n_interp > 1) {
     //         return source_diff_n_interp;
@@ -48,10 +53,12 @@ public:
     // }
 
     // inline std::vector<Real> get_subvector_sources(const Size curr_idx) const {
-    //     Size curr_line_start_idx = model.lines.get_index(curr_idx, 0);//assumes all data from any point lies next to eachother in the vector
-    //     Size curr_line_end_idx = model.lines.get_index(curr_idx + 1, 0);
+    //     Size curr_line_start_idx = model.lines.get_index(curr_idx, 0);//assumes all data from any
+    //     point lies next to eachother in the vector Size curr_line_end_idx =
+    //     model.lines.get_index(curr_idx + 1, 0);
 
-    //     return std::vector<Real>(self.line_sources.begin() + curr_line_start_idx, self.line_sources.begin() + curr_line_end_idx);
+    //     return std::vector<Real>(self.line_sources.begin() + curr_line_start_idx,
+    //     self.line_sources.begin() + curr_line_end_idx);
     // }
 };
 

--- a/src/solver/solver_interp_helper.tpp
+++ b/src/solver/solver_interp_helper.tpp
@@ -4,17 +4,33 @@
 ///    @param[in] next_idx : index of the next point
 ///    @returns number of points to interpolate
 /////////////////////////////////////////////////
-/// TODO: currently, this will probably result in too much interpolation, as the resulting grid is uniform for all lines/frequencies.
-inline Size InterpHelper::get_n_interp(const Model& model, const Size curr_idx, const Size next_idx) const {
-    std::vector<Real> curr_sources = get_subvector_sources(model, curr_idx);
-    std::vector<Real> next_sources = get_subvector_sources(model, next_idx);
+/// TODO: currently, this will probably result in too much interpolation, as the resulting grid is
+/// uniform for all lines/frequencies.
+inline Size InterpHelper::get_n_interp(
+    const Model& model, const Size curr_idx, const Size next_idx) const {
+    std::vector<Real> curr_sources = get_subvector_interpolation_criterion(model, curr_idx);
+    std::vector<Real> next_sources = get_subvector_interpolation_criterion(model, next_idx);
     // get relative difference between sources
     std::vector<Real> sources_diff;
-    sources_diff.reserve(curr_sources.size());
-    std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(), sources_diff.begin(), [](Real x, Real y) { return x/y; });
-    // convert to ln, and take absolute value
-    std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(), [](Real x) { return fabs(log(x)); });
-    const Size source_diff_n_interp = std::ceil(*std::max_element(sources_diff.begin(), sources_diff.end())/std::log(max_source_diff));
+    sources_diff.resize(curr_sources.size());
+    // in linear space
+    std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(),
+        sources_diff.begin(), [](Real x, Real y) { return std::abs(x - y) / std::min(x, y); });
+    const Size source_diff_n_interp = std::ceil(
+        *std::max_element(sources_diff.begin(), sources_diff.end()) / (max_source_diff - 1.0));
+    // debug: also compute max source diff
+    Real print_source_diff = *std::max_element(sources_diff.begin(), sources_diff.end());
+    // in log space
+    // std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(),
+    //     sources_diff.begin(), [](Real x, Real y) { return x / y; });
+    // // convert to ln, and take absolute value
+    // std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(),
+    //     [](Real x) { return fabs(log(x)); });
+    // const Size source_diff_n_interp = std::ceil(
+    //     *std::max_element(sources_diff.begin(), sources_diff.end()) / std::log(max_source_diff));
+    // std::cout << "regular interp: " << source_diff_n_interp << " curridx: " << curr_idx
+    //           << " nextidx: " << next_idx << " max source diff: " << print_source_diff <<
+    //           std::endl;
 
     if (source_diff_n_interp > 1) {
         return source_diff_n_interp;
@@ -23,19 +39,77 @@ inline Size InterpHelper::get_n_interp(const Model& model, const Size curr_idx, 
     }
 }
 
-inline std::vector<Real> InterpHelper::get_subvector_sources(const Model& model, const Size curr_idx) const {
-    Size curr_line_start_idx = model.lines.index(curr_idx, 0);//assumes all data from any point lies next to eachother in the vector
+///  Get the number of points to interpolate between two points
+///    @param[in] curr_idx : index of the current point
+///    @param[in] next_idx : index of the next point
+///    @returns number of points to interpolate
+/////////////////////////////////////////////////
+/// TODO: currently, this will probably result in too much interpolation, as the resulting grid is
+/// uniform for all lines/frequencies.
+inline Size InterpHelper::get_n_interp_for_line(
+    const Model& model, const Size l, const Size curr_idx, const Size next_idx) const {
+    Real curr_source = interpolation_criterion[model.lines.index(curr_idx, l)];
+    Real next_source = interpolation_criterion[model.lines.index(next_idx, l)];
+    // in linear space
+    Real source_diff                = std::abs(next_source - curr_source);
+    Real min_source                 = std::min(next_source, curr_source);
+    const Size source_diff_n_interp = std::ceil(source_diff / (min_source * (max_source_diff - 1)));
+    // debug: also compute max source diff
+    Real max_source_diff = source_diff / min_source;
+    // // get relative difference between sources
+    // log spacing
+    // std::vector<Real> sources_diff;
+    // sources_diff.resize(curr_sources.size());
+    // std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(),
+    //     sources_diff.begin(), [](Real x, Real y) { return x / y; });
+    // // convert to ln, and take absolute value
+    // std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(),
+    //     [](Real x) { return fabs(log(x)); });
+    // const Size source_diff_n_interp = std::ceil(
+    //     *std::max_element(sources_diff.begin(), sources_diff.end()) / std::log(max_source_diff));
+    // std::cout << "line interp: " << source_diff_n_interp << " curridx: " << curr_idx
+    //           << " nextidx: " << next_idx << " max source diff: " << max_source_diff <<
+    //           std::endl;
+
+    if (source_diff_n_interp > 1) {
+        return source_diff_n_interp;
+    } else {
+        return 1;
+    }
+}
+
+inline std::vector<Real> InterpHelper::get_subvector_interpolation_criterion(
+    const Model& model, const Size curr_idx) const {
+    Size curr_line_start_idx = model.lines.index(
+        curr_idx, 0); // assumes all data from any point lies next to eachother in the vector
     Size curr_line_end_idx = model.lines.index(curr_idx + 1, 0);
 
-    return std::vector<Real>(line_sources.begin() + curr_line_start_idx, line_sources.begin() + curr_line_end_idx);
+    return std::vector<Real>(interpolation_criterion.begin() + curr_line_start_idx,
+        interpolation_criterion.begin() + curr_line_end_idx);
 }
 
 ///  Linear interpolation of f(x) in interval [0,1]
-inline Real InterpHelper::interpolate_linear(const Real f_start, const Real f_end, const Real factor) const {
+inline Real InterpHelper::interpolate_linear(
+    const Real f_start, const Real f_end, const Real factor) const {
+    if (factor == 0.0) {
+        return f_start;
+    } else if (factor == 1.0) {
+        return f_end;
+    }
     return (f_end - f_start) * factor + f_start;
 }
 
 ///  Logarithmic interpolation of f(x) in interval [0,1]
-inline Real InterpHelper::interpolate_log(const Real f_start, const Real f_end, const Real factor) const {
-    return exp((log(f_end) - log(f_start)) * factor + log(f_start));
+inline Real InterpHelper::interpolate_log(
+    const Real f_start, const Real f_end, const Real factor) const {
+    // TESTING timings; log interpolation might just prove to be too expensive
+    return interpolate_linear(f_start, f_end, factor);
+    // log is way too expensive to use without essentially doing anything
+    // if (factor == 0.0) { //<- branch prediction should be here most of the time; assumes
+    //                      // interpolation to only be used for a small part of the model
+    //     return f_start;
+    // } else if (factor == 1.0) {
+    //     return f_end;
+    // }
+    // return exp((log(f_end) - log(f_start)) * factor + log(f_start));
 }

--- a/src/solver/solver_interp_helper.tpp
+++ b/src/solver/solver_interp_helper.tpp
@@ -8,26 +8,37 @@
 /// uniform for all lines/frequencies.
 inline Size InterpHelper::get_n_interp(
     const Model& model, const Size curr_idx, const Size next_idx) const {
-    std::vector<Real> curr_sources = get_subvector_interpolation_criterion(model, curr_idx);
-    std::vector<Real> next_sources = get_subvector_interpolation_criterion(model, next_idx);
+    // std::vector<Real> curr_sources = get_subvector_interpolation_criterion(model, curr_idx);
+    // std::vector<Real> next_sources = get_subvector_interpolation_criterion(model, next_idx);
+
+    Size curr_line_start_idx = model.lines.index(
+        curr_idx, 0); // assumes all data from any point lies next to eachother in the vector
+    Size curr_line_end_idx = model.lines.index(curr_idx + 1, 0);
+
+    Size next_line_start_idx = model.lines.index(
+        next_idx, 0); // assumes all data from any point lies next to eachother in the vector
+    Size next_line_end_idx = model.lines.index(next_idx + 1, 0);
+
     // get relative difference between sources
     std::vector<Real> sources_diff;
-    sources_diff.resize(curr_sources.size());
+    sources_diff.resize(model.parameters->nlines());
     // in linear space
-    std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(),
-        sources_diff.begin(), [](Real x, Real y) { return std::abs(x - y) / std::min(x, y); });
-    const Size source_diff_n_interp = std::ceil(
-        *std::max_element(sources_diff.begin(), sources_diff.end()) / (max_source_diff - 1.0));
-    // debug: also compute max source diff
-    Real print_source_diff = *std::max_element(sources_diff.begin(), sources_diff.end());
+    // std::transform(interpolation_criterion.begin() + next_line_start_idx,
+    //     interpolation_criterion.begin() + next_line_end_idx,
+    //     interpolation_criterion.begin() + curr_line_start_idx, sources_diff.begin(),
+    //     [](Real x, Real y) { return std::abs(x - y) / std::min(x, y); });
+    // const Size source_diff_n_interp = std::ceil(
+    //     *std::max_element(sources_diff.begin(), sources_diff.end()) / (max_source_diff - 1.0));
     // in log space
-    // std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(),
-    //     sources_diff.begin(), [](Real x, Real y) { return x / y; });
-    // // convert to ln, and take absolute value
+    std::transform(interpolation_criterion.begin() + next_line_start_idx,
+        interpolation_criterion.begin() + next_line_end_idx,
+        interpolation_criterion.begin() + curr_line_start_idx, sources_diff.begin(),
+        [](Real x, Real y) { return fabs(logf(x / y)); });
+    // convert to ln, and take absolute value
     // std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(),
     //     [](Real x) { return fabs(log(x)); });
-    // const Size source_diff_n_interp = std::ceil(
-    //     *std::max_element(sources_diff.begin(), sources_diff.end()) / std::log(max_source_diff));
+    const Size source_diff_n_interp = std::ceil(
+        *std::max_element(sources_diff.begin(), sources_diff.end()) / logf(max_source_diff));
     // std::cout << "regular interp: " << source_diff_n_interp << " curridx: " << curr_idx
     //           << " nextidx: " << next_idx << " max source diff: " << print_source_diff <<
     //           std::endl;
@@ -50,14 +61,15 @@ inline Size InterpHelper::get_n_interp_for_line(
     const Model& model, const Size l, const Size curr_idx, const Size next_idx) const {
     Real curr_source = interpolation_criterion[model.lines.index(curr_idx, l)];
     Real next_source = interpolation_criterion[model.lines.index(next_idx, l)];
-    // in linear space
-    Real source_diff                = std::abs(next_source - curr_source);
-    Real min_source                 = std::min(next_source, curr_source);
-    const Size source_diff_n_interp = std::ceil(source_diff / (min_source * (max_source_diff - 1)));
-    // debug: also compute max source diff
-    Real max_source_diff = source_diff / min_source;
+    // // in linear space
+    // Real source_diff                = std::abs(next_source - curr_source);
+    // Real min_source                 = std::min(next_source, curr_source);
+    // const Size source_diff_n_interp = std::ceil(source_diff / (min_source * (max_source_diff -
+    // 1))); debug: also compute max source diff
     // // get relative difference between sources
-    // log spacing
+    // log spacing (required for the large opacity differences)
+    Real source_diff                = std::abs(logf(next_source / curr_source));
+    const Size source_diff_n_interp = std::ceil(source_diff / logf(max_source_diff));
     // std::vector<Real> sources_diff;
     // sources_diff.resize(curr_sources.size());
     // std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(),
@@ -103,13 +115,16 @@ inline Real InterpHelper::interpolate_linear(
 inline Real InterpHelper::interpolate_log(
     const Real f_start, const Real f_end, const Real factor) const {
     // TESTING timings; log interpolation might just prove to be too expensive
-    return interpolate_linear(f_start, f_end, factor);
+    // return interpolate_linear(f_start, f_end, factor);
     // log is way too expensive to use without essentially doing anything
-    // if (factor == 0.0) { //<- branch prediction should be here most of the time; assumes
-    //                      // interpolation to only be used for a small part of the model
-    //     return f_start;
-    // } else if (factor == 1.0) {
-    //     return f_end;
-    // }
-    // return exp((log(f_end) - log(f_start)) * factor + log(f_start));
+    if (factor == 0.0) { //<- branch prediction should be here most of the time; assumes
+                         // interpolation to only be used for a small part of the model
+        return f_start;
+    } else if (factor == 1.0) {
+        return f_end;
+    }
+    // Note: accuracy is not that important here, so logf/expf should be fine
+    // return expf((logf(f_end) - logf(f_start)) * factor + logf(f_start));
+    // can be simplified to:
+    return f_start * powf(f_end / f_start, factor);
 }

--- a/src/solver/solver_interp_helper.tpp
+++ b/src/solver/solver_interp_helper.tpp
@@ -5,7 +5,7 @@
 ///    @returns number of points to interpolate
 /////////////////////////////////////////////////
 /// TODO: currently, this will probably result in too much interpolation, as the resulting grid is uniform for all lines/frequencies.
-inline Size InterpHelper::get_n_interp(Model& model, const Size curr_idx, const Size next_idx) const {
+inline Size InterpHelper::get_n_interp(const Model& model, const Size curr_idx, const Size next_idx) const {
     std::vector<Real> curr_sources = get_subvector_sources(model, curr_idx);
     std::vector<Real> next_sources = get_subvector_sources(model, next_idx);
     // get relative difference between sources
@@ -23,7 +23,7 @@ inline Size InterpHelper::get_n_interp(Model& model, const Size curr_idx, const 
     }
 }
 
-inline std::vector<Real> InterpHelper::get_subvector_sources(Model& model, const Size curr_idx) const {
+inline std::vector<Real> InterpHelper::get_subvector_sources(const Model& model, const Size curr_idx) const {
     Size curr_line_start_idx = model.lines.index(curr_idx, 0);//assumes all data from any point lies next to eachother in the vector
     Size curr_line_end_idx = model.lines.index(curr_idx + 1, 0);
 
@@ -32,10 +32,10 @@ inline std::vector<Real> InterpHelper::get_subvector_sources(Model& model, const
 
 ///  Linear interpolation of f(x) in interval [0,1]
 inline Real InterpHelper::interpolate_linear(const Real f_start, const Real f_end, const Real factor) const {
-    return (x_end - x_start) * factor + x_start;
+    return (f_end - f_start) * factor + f_start;
 }
 
 ///  Logarithmic interpolation of f(x) in interval [0,1]
 inline Real InterpHelper::interpolate_log(const Real f_start, const Real f_end, const Real factor) const {
-    return exp((log(x_end) - log(x_start)) * factor + log(x_start));
+    return exp((log(f_end) - log(f_start)) * factor + log(f_start));
 }

--- a/src/solver/solver_interp_helper.tpp
+++ b/src/solver/solver_interp_helper.tpp
@@ -1,0 +1,41 @@
+
+///  Get the number of points to interpolate between two points
+///    @param[in] curr_idx : index of the current point
+///    @param[in] next_idx : index of the next point
+///    @returns number of points to interpolate
+/////////////////////////////////////////////////
+/// TODO: currently, this will probably result in too much interpolation, as the resulting grid is uniform for all lines/frequencies.
+inline Size InterpHelper::get_n_interp(Model& model, const Size curr_idx, const Size next_idx) const {
+    std::vector<Real> curr_sources = get_subvector_sources(model, curr_idx);
+    std::vector<Real> next_sources = get_subvector_sources(model, next_idx);
+    // get relative difference between sources
+    std::vector<Real> sources_diff;
+    sources_diff.reserve(curr_sources.size());
+    std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(), sources_diff.begin(), [](Real x, Real y) { return x/y; });
+    // convert to ln, and take absolute value
+    std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(), [](Real x) { return fabs(log(x)); });
+    const Size source_diff_n_interp = std::ceil(*std::max_element(sources_diff.begin(), sources_diff.end())/std::log(max_source_diff));
+
+    if (source_diff_n_interp > 1) {
+        return source_diff_n_interp;
+    } else {
+        return 1;
+    }
+}
+
+inline std::vector<Real> InterpHelper::get_subvector_sources(Model& model, const Size curr_idx) const {
+    Size curr_line_start_idx = model.lines.index(curr_idx, 0);//assumes all data from any point lies next to eachother in the vector
+    Size curr_line_end_idx = model.lines.index(curr_idx + 1, 0);
+
+    return std::vector<Real>(line_sources.begin() + curr_line_start_idx, line_sources.begin() + curr_line_end_idx);
+}
+
+///  Linear interpolation of f(x) in interval [0,1]
+inline Real InterpHelper::interpolate_linear(const Real f_start, const Real f_end, const Real factor) const {
+    return (x_end - x_start) * factor + x_start;
+}
+
+///  Logarithmic interpolation of f(x) in interval [0,1]
+inline Real InterpHelper::interpolate_log(const Real f_start, const Real f_end, const Real factor) const {
+    return exp((log(x_end) - log(x_start)) * factor + log(x_start));
+}

--- a/src/solver/solver_interp_helper.tpp
+++ b/src/solver/solver_interp_helper.tpp
@@ -4,12 +4,11 @@
 ///    @param[in] next_idx : index of the next point
 ///    @returns number of points to interpolate
 /////////////////////////////////////////////////
-/// TODO: currently, this will probably result in too much interpolation, as the resulting grid is
-/// uniform for all lines/frequencies.
+/// Note: this will result in too much interpolation, as not all frequencies around each line need
+/// the same interpolation points uniform for all lines/frequencies. Evidently, this is an upper
+/// bound for get_n_interp_for_line.
 inline Size InterpHelper::get_n_interp(
     const Model& model, const Size curr_idx, const Size next_idx) const {
-    // std::vector<Real> curr_sources = get_subvector_interpolation_criterion(model, curr_idx);
-    // std::vector<Real> next_sources = get_subvector_interpolation_criterion(model, next_idx);
 
     Size curr_line_start_idx = model.lines.index(
         curr_idx, 0); // assumes all data from any point lies next to eachother in the vector
@@ -22,6 +21,7 @@ inline Size InterpHelper::get_n_interp(
     // get relative difference between sources
     std::vector<Real> sources_diff;
     sources_diff.resize(model.parameters->nlines());
+
     // in linear space
     // std::transform(interpolation_criterion.begin() + next_line_start_idx,
     //     interpolation_criterion.begin() + next_line_end_idx,
@@ -29,19 +29,14 @@ inline Size InterpHelper::get_n_interp(
     //     [](Real x, Real y) { return std::abs(x - y) / std::min(x, y); });
     // const Size source_diff_n_interp = std::ceil(
     //     *std::max_element(sources_diff.begin(), sources_diff.end()) / (max_source_diff - 1.0));
+
     // in log space
     std::transform(interpolation_criterion.begin() + next_line_start_idx,
         interpolation_criterion.begin() + next_line_end_idx,
         interpolation_criterion.begin() + curr_line_start_idx, sources_diff.begin(),
         [](Real x, Real y) { return fabs(logf(x / y)); });
-    // convert to ln, and take absolute value
-    // std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(),
-    //     [](Real x) { return fabs(log(x)); });
     const Size source_diff_n_interp = std::ceil(
         *std::max_element(sources_diff.begin(), sources_diff.end()) / logf(max_source_diff));
-    // std::cout << "regular interp: " << source_diff_n_interp << " curridx: " << curr_idx
-    //           << " nextidx: " << next_idx << " max source diff: " << print_source_diff <<
-    //           std::endl;
 
     if (source_diff_n_interp > 1) {
         return source_diff_n_interp;
@@ -55,49 +50,28 @@ inline Size InterpHelper::get_n_interp(
 ///    @param[in] next_idx : index of the next point
 ///    @returns number of points to interpolate
 /////////////////////////////////////////////////
-/// TODO: currently, this will probably result in too much interpolation, as the resulting grid is
-/// uniform for all lines/frequencies.
+/// Note: current interpolation assumes that every line is fully seperated from the others, which
+/// might not be the case for overlapping lines. FIXME: add better interpolation criterion
 inline Size InterpHelper::get_n_interp_for_line(
     const Model& model, const Size l, const Size curr_idx, const Size next_idx) const {
     Real curr_source = interpolation_criterion[model.lines.index(curr_idx, l)];
     Real next_source = interpolation_criterion[model.lines.index(next_idx, l)];
-    // // in linear space
+
+    // in linear space
     // Real source_diff                = std::abs(next_source - curr_source);
     // Real min_source                 = std::min(next_source, curr_source);
     // const Size source_diff_n_interp = std::ceil(source_diff / (min_source * (max_source_diff -
-    // 1))); debug: also compute max source diff
-    // // get relative difference between sources
-    // log spacing (required for the large opacity differences)
+    // 1)));
+
+    // in log space
     Real source_diff                = std::abs(logf(next_source / curr_source));
     const Size source_diff_n_interp = std::ceil(source_diff / logf(max_source_diff));
-    // std::vector<Real> sources_diff;
-    // sources_diff.resize(curr_sources.size());
-    // std::transform(next_sources.begin(), next_sources.end(), curr_sources.begin(),
-    //     sources_diff.begin(), [](Real x, Real y) { return x / y; });
-    // // convert to ln, and take absolute value
-    // std::transform(sources_diff.begin(), sources_diff.end(), sources_diff.begin(),
-    //     [](Real x) { return fabs(log(x)); });
-    // const Size source_diff_n_interp = std::ceil(
-    //     *std::max_element(sources_diff.begin(), sources_diff.end()) / std::log(max_source_diff));
-    // std::cout << "line interp: " << source_diff_n_interp << " curridx: " << curr_idx
-    //           << " nextidx: " << next_idx << " max source diff: " << max_source_diff <<
-    //           std::endl;
 
     if (source_diff_n_interp > 1) {
         return source_diff_n_interp;
     } else {
         return 1;
     }
-}
-
-inline std::vector<Real> InterpHelper::get_subvector_interpolation_criterion(
-    const Model& model, const Size curr_idx) const {
-    Size curr_line_start_idx = model.lines.index(
-        curr_idx, 0); // assumes all data from any point lies next to eachother in the vector
-    Size curr_line_end_idx = model.lines.index(curr_idx + 1, 0);
-
-    return std::vector<Real>(interpolation_criterion.begin() + curr_line_start_idx,
-        interpolation_criterion.begin() + curr_line_end_idx);
 }
 
 ///  Linear interpolation of f(x) in interval [0,1]
@@ -114,8 +88,6 @@ inline Real InterpHelper::interpolate_linear(
 ///  Logarithmic interpolation of f(x) in interval [0,1]
 inline Real InterpHelper::interpolate_log(
     const Real f_start, const Real f_end, const Real factor) const {
-    // TESTING timings; log interpolation might just prove to be too expensive
-    // return interpolate_linear(f_start, f_end, factor);
     // log is way too expensive to use without essentially doing anything
     if (factor == 0.0) { //<- branch prediction should be here most of the time; assumes
                          // interpolation to only be used for a small part of the model
@@ -123,8 +95,5 @@ inline Real InterpHelper::interpolate_log(
     } else if (factor == 1.0) {
         return f_end;
     }
-    // Note: accuracy is not that important here, so logf/expf should be fine
-    // return expf((logf(f_end) - logf(f_start)) * factor + logf(f_start));
-    // can be simplified to:
     return f_start * powf(f_end / f_start, factor);
 }

--- a/tests/benchmarks/analytic/all_constant_single_ray.py
+++ b/tests/benchmarks/analytic/all_constant_single_ray.py
@@ -93,7 +93,7 @@ def run_model (nosave=False):
     timer3.stop()
     u_0s = np.array(model.radiation.u)
 
-    timer4 = tools.Timer('feautrier 2  ')
+    timer4 = tools.Timer('feautrier 2 ')
     timer4.start()
     model.compute_radiation_field_feautrier_order_2 ()
     timer4.stop()
@@ -178,7 +178,7 @@ def run_model (nosave=False):
 
     #error bounds are chosen somewhat arbitrarily, based on previously obtained results; this should prevent serious regressions.
     FEAUTRIER_AS_EXPECTED=(np.max(error_u_2f)<1.7e-4)
-    FIRSTORDER_AS_EXPECTED=(np.max(error_u_0s)<5.1e-8)
+    FIRSTORDER_AS_EXPECTED=(np.max(error_u_0s)<1.7e-7)
     FEAUTRIER_UV_AS_EXPECTED=(np.max(error_I_0_2f_uv)<2.0e-4) and (np.max(error_I_1_2f_uv)<2.0e-4)
 
     if not FIRSTORDER_AS_EXPECTED:

--- a/tests/benchmarks/analytic/all_zero_single_ray.py
+++ b/tests/benchmarks/analytic/all_zero_single_ray.py
@@ -104,7 +104,6 @@ def run_model (nosave=False):
     model.compute_radiation_field_shortchar_order_0 ()
     timer3.stop()
     u_0s = np.array(model.radiation.u)
-    print(u_0s)
 
     timer4 = tools.Timer('feautrier 2  ')
     timer4.start()
@@ -179,7 +178,7 @@ def run_model (nosave=False):
         plt.show()
 
     #error bounds are chosen somewhat arbitrarily, based on previously obtained results; this should prevent serious regressions.
-    FIRSTORDER_AS_EXPECTED=(np.max(error_u_0s)<6.42e-6)
+    FIRSTORDER_AS_EXPECTED=(np.max(error_u_0s)<6.57e-6)
     FEAUTRIER_AS_EXPECTED=(np.max(error_u_2f)<6.41e-6)
 
     if not FIRSTORDER_AS_EXPECTED:

--- a/tests/benchmarks/analytic/constant_velocity_gradient_1D.py
+++ b/tests/benchmarks/analytic/constant_velocity_gradient_1D.py
@@ -189,6 +189,7 @@ def run_model (nosave=False, benchindex=0, use_widgets=True):
         plt.figure(dpi=150)
         plt.plot(fs, us  [r,p,:], marker='.')
         plt.plot(fs, u_2f[r,p,:])
+        plt.plot(fs, u_0s[r,p,:])
 
     #during automated testing, the widgets only consume time to create
     if use_widgets:
@@ -246,13 +247,13 @@ def run_model (nosave=False, benchindex=0, use_widgets=True):
     #if we are actually doing benchmarks, the accuracy will depend on how accurately we compute the optical depth
     if (benchindex==1):
         FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<1e-6)
-        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<1e-6)
+        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<1.1e-6)
     elif(benchindex==2):
         FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<5e-7)
-        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<5e-7)
+        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<5.1e-7)
     elif(benchindex==3):
         FEAUTRIER_AS_EXPECTED=(np.mean(error_u_2f)<5.31e-8)
-        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<5.42e-8)
+        FIRSTORDER_AS_EXPECTED=(np.mean(error_u_0s)<5.91e-8)
 
     if not FIRSTORDER_AS_EXPECTED:
         print("First order solver mean error too large: ", np.mean(error_u_0s), "bench nr: ", benchindex)

--- a/tests/benchmarks/analytic/density_distribution_1D.py
+++ b/tests/benchmarks/analytic/density_distribution_1D.py
@@ -194,7 +194,7 @@ def run_model (a_or_b, nosave=False, use_widgets=True):
     error_u_0s = np.abs(tools.relative_error(us, u_0s)[:-1, :-1, :])
     error_u_2f = np.abs(tools.relative_error(us, u_2f)[:-1, :-1, :])
 
-    log_err_min = np.log10(np.min([error_u_0s, error_u_2f]))
+    log_err_min = np.log10(max(np.min([error_u_0s, error_u_2f]), 1e-10))
     log_err_max = np.log10(np.max([error_u_0s, error_u_2f]))
 
     bins = np.logspace(log_err_min, log_err_max, 100)

--- a/tests/benchmarks/numeric/reduce_phantom_3D_model.py
+++ b/tests/benchmarks/numeric/reduce_phantom_3D_model.py
@@ -103,7 +103,7 @@ def reduce_phantom():
 
     setup.set_uniform_rays            (model)   # Uncomment to use all directions
     setup.set_boundary_condition_CMB  (model)
-    setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})
+    setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0,1,2,3]})#first 4 transitions for testing should suffice
     # model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions
     setup.set_quadrature              (model)
 

--- a/tests/benchmarks/numeric/reduce_phantom_3D_model.py
+++ b/tests/benchmarks/numeric/reduce_phantom_3D_model.py
@@ -103,7 +103,7 @@ def reduce_phantom():
 
     setup.set_uniform_rays            (model)   # Uncomment to use all directions
     setup.set_boundary_condition_CMB  (model)
-    setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0,1,2,3]})#first 4 transitions for testing should suffice
+    setup.set_linedata_from_LAMDA_file(model, lamda_file, {'considered transitions': [0]})#first transition for testing
     # model = setup.set_linedata_from_LAMDA_file(model, lamda_file)   # Consider all transitions
     setup.set_quadrature              (model)
 

--- a/tests/benchmarks/numeric/run_phantom_3D_model_reduced.py
+++ b/tests/benchmarks/numeric/run_phantom_3D_model_reduced.py
@@ -12,8 +12,10 @@ import matplotlib.pyplot as plt
 import magritte.tools    as tools
 import magritte.setup    as setup
 import magritte.core     as magritte
+import magritte.plot as plot
 
-VERSION = "0.7.2"#reference version of Magritte to compare against; should correspond to a commited intensity file
+VERSION = "0.9.0"#reference version of Magritte to compare against; should correspond to a commited intensity file
+#starting from 0.9.0, we compute the intensity for 4 lines at the same time, instead of just a single line. This is still not a realistic usecase, but suffices for regression testing.
 
 path = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/benchmarks/numeric/run_phantom_3D_model_reduced_reference.py
+++ b/tests/benchmarks/numeric/run_phantom_3D_model_reduced_reference.py
@@ -20,7 +20,8 @@ result_dir= path+"/../../results/"
 redux_file = os.path.join(modeldir, 'wind_red.hdf5' )   # Reduced Magritte model
 # lamda_file = os.path.join(datadir, 'co.txt'                )   # Line data file
 
-VERSION = version('magritte')
+VERSION = version('magritte')#TODO: figure out how to instead use the next version here, instead pf manually settiing it
+
 
 def run_model (nosave=True):
 


### PR DESCRIPTION
Adds interpolation for source function, opacity, emissivity (log interpolation) and line width (linear interpolation).
Note: This new interpolation is mandatory and slightly (about a factor 1.3) slower than the previous magritte version in models without interpolation.

Features:
- Interpolation based on difference in line opacity
- New parameter max_interpolation_diff for regulating how much interpolation points are needed
- The parameter min_line_opacity can (and should) now be put much lower (new default 1e-13, prev default 1e-10)
- Updated docs concerning relevant parameters to set
- Should fix #271 and all previous related issues