### PR TITLE
Apparently, there was a off-by-one error issue when interpolating.

### DIFF
--- a/src/model/lines/lineProducingSpecies/linedata/collisionPartner/collisionPartner.tpp
+++ b/src/model/lines/lineProducingSpecies/linedata/collisionPartner/collisionPartner.tpp
@@ -9,7 +9,7 @@ inline void CollisionPartner ::interpolate_collision_coefficients(const Real tem
     if (t == 0) {
         Ce_intpld() = Ce[0];
         Cd_intpld() = Cd[0];
-    } else if (t == ntmp - 1) {
+    } else if (t == ntmp) {
         Ce_intpld() = Ce[ntmp - 1];
         Cd_intpld() = Cd[ntmp - 1];
     } else {

--- a/src/tools/interpolation.hpp
+++ b/src/tools/interpolation.hpp
@@ -2,7 +2,7 @@
 
 #include "tools/types.hpp"
 
-///  Binary search for the index of a value right above a value in a list
+///  Binary search for the index with value just above the given value
 ///  @param[in] x: vector of tabulated argument values
 ///  @param[in] value: value to search for
 ///  @return index of x table just above value
@@ -12,7 +12,7 @@ inline Size search(const Real1& x, const Real value) {
     Size stop  = x.size() - 1;
 
     if (value >= x[stop]) {
-        return stop;
+        return stop + 1; // need additional value to indicate out of bounds for max value
     } else if (value <= x[start]) {
         return start;
     }


### PR DESCRIPTION
This is is now fixed. Note: although I'm still not entirely convinced about the ALI implementation, but the extremely dense regions are dominated by the collisional rates anyway.